### PR TITLE
WonderBox Stage 5 — Supabase logging + editable rules + spelling polish

### DIFF
--- a/questionbox/server/.env.example
+++ b/questionbox/server/.env.example
@@ -26,10 +26,13 @@ OPENAI_API_KEY=
 # ELEVENLABS_VOICE_ID=
 # ELEVENLABS_MODEL_ID=eleven_flash_v2_5
 
-# --- Stage 5 (Supabase logging + config) ---------------------------------
-# NEXT_PUBLIC_SUPABASE_URL=
-# NEXT_PUBLIC_SUPABASE_ANON_KEY=
-# SUPABASE_SERVICE_ROLE_KEY=
+# --- Stage 5 (Supabase logging + editable rules; NEEDED NOW) -------------
+# Create a project at https://supabase.com, run supabase/schema.sql in the SQL
+# editor, then copy these from Project Settings -> API.
+# The SERVICE ROLE key is a server-only secret — never expose it to a browser.
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
 
 # --- Stage 7 (daily digest email) ----------------------------------------
 # RESEND_API_KEY=

--- a/questionbox/server/README.md
+++ b/questionbox/server/README.md
@@ -33,12 +33,29 @@ Four layers; a bad answer must beat **all** of them, and we **default to defer**
 Spelling questions are handled deterministically and safely (the requested word
 is spelled out; blocked words are deferred).
 
-**The allow/deny rules live in `lib/safety/rules.ts`** (moving to Supabase in
-Stage 5 so you can edit them from the dashboard). ALLOW: how things work,
-animals, nature, space, science, simple math, shapes/colors, definitions,
-spelling, simple geography. DEFER: opinions, feelings, news, politics, religion,
-death, violence/weapons, scary, sex/where-babies-come-from, medical, specific
-real people, money — plus REFUSE for attempts to change the rules.
+**The allow/deny rules are editable config.** They ship as defaults in
+`lib/safety/rules.ts` and, once Supabase is set up, are loaded from the
+`topic_rules` table (seeded automatically on first run) so you can edit them from
+the dashboard without a code change. ALLOW: how things work, animals, nature,
+space, science, simple math, shapes/colors, definitions, spelling, simple
+geography. DEFER: opinions, feelings, news, politics, religion, death,
+violence/weapons, scary, sex/where-babies-come-from, medical, specific real
+people, money — plus REFUSE for attempts to change the rules.
+
+### Logging (Stage 5)
+
+Every interaction is logged to Supabase — **text only**: timestamp, transcribed
+question, answer, whether it was `answered`/`deferred`/`refused` and why (plus
+`is_spelling`/`spell_word` and latency). **Audio is never logged or stored.**
+Logging is best-effort: a logging failure never breaks a child's answer, and if
+Supabase isn't configured, logging is simply skipped.
+
+**Setup:** create a project at [supabase.com](https://supabase.com), run
+[`supabase/schema.sql`](supabase/schema.sql) in the SQL editor, then add
+`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and
+`SUPABASE_SERVICE_ROLE_KEY` to your env (Vercel). RLS is on with no public
+policies — only the server's service role can read/write; the dashboard
+(Stage 6) reads via the server after authenticating you.
 
 ## The device↔server contract
 

--- a/questionbox/server/__tests__/log.test.ts
+++ b/questionbox/server/__tests__/log.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { logInteraction } from "@/lib/log";
+
+describe("interaction logging", () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  it("is a no-op (and never throws) when Supabase is not configured", async () => {
+    await expect(
+      logInteraction({
+        question: "how far is the moon",
+        answer: "The moon is very far away!",
+        mode: "answered",
+        isSpelling: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/questionbox/server/__tests__/pipeline.test.ts
+++ b/questionbox/server/__tests__/pipeline.test.ts
@@ -111,7 +111,7 @@ describe("pipeline — spelling is handled safely and deterministically", () => 
     expect(res.mode).toBe("answered");
     expect(res.isSpelling).toBe(true);
     expect(res.spellWord).toBe("DOG");
-    expect(res.text).toContain("D, O, G");
+    expect(res.text).toContain("D. O. G");
     expect(deps.generate).not.toHaveBeenCalled();
   });
 });

--- a/questionbox/server/__tests__/rules-store.test.ts
+++ b/questionbox/server/__tests__/rules-store.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRules, _clearRulesCache } from "@/lib/safety/rules-store";
+import { DEFAULT_RULES } from "@/lib/safety/rules";
+
+describe("rules store", () => {
+  beforeEach(() => {
+    _clearRulesCache();
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+  afterEach(() => {
+    _clearRulesCache();
+  });
+
+  it("falls back to DEFAULT_RULES when Supabase is not configured", async () => {
+    const rules = await getRules();
+    expect(rules).toBe(DEFAULT_RULES);
+    expect(rules.deny.length).toBeGreaterThan(0);
+  });
+});

--- a/questionbox/server/app/api/ask/route.ts
+++ b/questionbox/server/app/api/ask/route.ts
@@ -4,8 +4,11 @@ import { generateChimeWav } from "@/lib/wav";
 import { hasOpenAI } from "@/lib/ai/openai";
 import { transcribe } from "@/lib/ai/stt";
 import { synthesize } from "@/lib/ai/tts";
-import { realDeps } from "@/lib/ai/deps";
+import { makeRealDeps } from "@/lib/ai/deps";
 import { answerQuestion } from "@/lib/pipeline";
+import { getRules } from "@/lib/safety/rules-store";
+import { logInteraction } from "@/lib/log";
+import { isSupabaseConfigured } from "@/lib/supabase";
 import { setupMessage, troubleMessage } from "@/lib/safety/messages";
 
 export const runtime = "nodejs";
@@ -45,6 +48,8 @@ export async function POST(request: Request): Promise<Response> {
     return buildAnswerResponse({ text, mode: "deferred", isSpelling: false, wav: generateChimeWav() });
   }
 
+  const startedAt = Date.now();
+
   // 1) Speech-to-text (audio discarded right after).
   let question = "";
   try {
@@ -56,12 +61,23 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // 2) Safety pipeline (2 gates + deterministic checks) -> answer text.
-  const result = await answerQuestion(question, realDeps);
+  const rules = await getRules(); // editable rules from Supabase (or defaults)
+  const result = await answerQuestion(question, makeRealDeps(rules), rules);
 
-  // Text-only logging (audio is never logged). Stage 5 writes this to Supabase.
+  // 3) Text-only logging to Supabase (audio is NEVER logged). Best-effort.
+  await logInteraction({
+    question,
+    answer: result.text,
+    mode: result.mode,
+    category: result.category,
+    reason: result.reason,
+    isSpelling: result.isSpelling,
+    spellWord: result.spellWord,
+    latencyMs: Date.now() - startedAt,
+  });
   console.log(`[ask] q="${question}" -> mode=${result.mode} cat=${result.category ?? "-"}`);
 
-  // 3) Text-to-speech.
+  // 4) Text-to-speech.
   const wav = await ttsOrChime(result.text);
 
   const answer: WonderAnswer = {
@@ -75,5 +91,12 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 export function GET(): Response {
-  return Response.json({ name: "WonderBox", endpoint: "/api/ask", stage: 4, ok: true, aiConfigured: hasOpenAI() });
+  return Response.json({
+    name: "WonderBox",
+    endpoint: "/api/ask",
+    stage: 5,
+    ok: true,
+    aiConfigured: hasOpenAI(),
+    loggingConfigured: isSupabaseConfigured(),
+  });
 }

--- a/questionbox/server/lib/ai/deps.ts
+++ b/questionbox/server/lib/ai/deps.ts
@@ -1,8 +1,14 @@
 import type { PipelineDeps } from "../pipeline";
+import type { SafetyRules } from "../safety/rules";
 import { classifyQuestion, generateAnswer } from "./llm";
 
-/** The real (OpenAI-backed) pipeline dependencies used by the /api/ask route. */
-export const realDeps: PipelineDeps = {
-  classify: classifyQuestion,
-  generate: generateAnswer,
-};
+/**
+ * Build the real (OpenAI-backed) pipeline dependencies bound to a specific set
+ * of safety rules (so the LLM prompts match the editable configuration).
+ */
+export function makeRealDeps(rules: SafetyRules): PipelineDeps {
+  return {
+    classify: (q) => classifyQuestion(q, rules),
+    generate: (q) => generateAnswer(q, rules),
+  };
+}

--- a/questionbox/server/lib/ai/llm.ts
+++ b/questionbox/server/lib/ai/llm.ts
@@ -1,5 +1,6 @@
 import { getOpenAI } from "./openai";
 import { buildAnswerSystemPrompt, buildClassifierPrompt } from "../safety/prompts";
+import { DEFAULT_RULES, type SafetyRules } from "../safety/rules";
 
 export interface LlmClassification {
   decision: "answer" | "defer" | "refuse";
@@ -8,7 +9,10 @@ export interface LlmClassification {
 }
 
 /** Gate 1: LLM classification. Defaults to "defer" on any parsing trouble. */
-export async function classifyQuestion(question: string): Promise<LlmClassification> {
+export async function classifyQuestion(
+  question: string,
+  rules: SafetyRules = DEFAULT_RULES,
+): Promise<LlmClassification> {
   const openai = getOpenAI();
   const model = process.env.LLM_MODEL || "gpt-4o-mini";
 
@@ -17,7 +21,7 @@ export async function classifyQuestion(question: string): Promise<LlmClassificat
     temperature: 0,
     response_format: { type: "json_object" },
     messages: [
-      { role: "system", content: buildClassifierPrompt() },
+      { role: "system", content: buildClassifierPrompt(rules) },
       { role: "user", content: question },
     ],
   });
@@ -35,7 +39,10 @@ export async function classifyQuestion(question: string): Promise<LlmClassificat
 }
 
 /** Gate 2: answer generation under the strict, kid-safe system prompt. */
-export async function generateAnswer(question: string): Promise<string> {
+export async function generateAnswer(
+  question: string,
+  rules: SafetyRules = DEFAULT_RULES,
+): Promise<string> {
   const openai = getOpenAI();
   const model = process.env.LLM_MODEL || "gpt-4o-mini";
 
@@ -44,7 +51,7 @@ export async function generateAnswer(question: string): Promise<string> {
     temperature: 0.4,
     max_tokens: 160,
     messages: [
-      { role: "system", content: buildAnswerSystemPrompt() },
+      { role: "system", content: buildAnswerSystemPrompt(rules) },
       { role: "user", content: question },
     ],
   });

--- a/questionbox/server/lib/log.ts
+++ b/questionbox/server/lib/log.ts
@@ -1,0 +1,41 @@
+/**
+ * Interaction logging. We store ONLY text: the timestamp, the transcribed
+ * question, the answer, whether it was answered/refused/deferred, and why.
+ * Audio is NEVER logged or stored. Logging is best-effort — a logging failure
+ * must never break a child's answer.
+ */
+import { getSupabaseAdmin, isSupabaseConfigured } from "./supabase";
+import type { AnswerMode } from "./answer";
+
+export interface InteractionLog {
+  question: string;
+  answer: string;
+  mode: AnswerMode;
+  category?: string;
+  reason?: string;
+  isSpelling: boolean;
+  spellWord?: string;
+  latencyMs?: number;
+  deviceId?: string;
+}
+
+export async function logInteraction(entry: InteractionLog): Promise<void> {
+  if (!isSupabaseConfigured()) return; // logging is optional
+  try {
+    const db = getSupabaseAdmin();
+    const { error } = await db.from("interactions").insert({
+      question: entry.question,
+      answer: entry.answer,
+      mode: entry.mode,
+      category: entry.category ?? null,
+      reason: entry.reason ?? null,
+      is_spelling: entry.isSpelling,
+      spell_word: entry.spellWord ?? null,
+      latency_ms: entry.latencyMs ?? null,
+      device_id: entry.deviceId ?? null,
+    });
+    if (error) throw error;
+  } catch (e) {
+    console.error("[log] failed to write interaction:", e);
+  }
+}

--- a/questionbox/server/lib/pipeline.ts
+++ b/questionbox/server/lib/pipeline.ts
@@ -14,6 +14,7 @@
 import { containsBlockedContent, detectSpelling, ruleCheck } from "./safety/classifier";
 import { deferMessage, refuseMessage } from "./safety/messages";
 import { DEFER_TOKEN } from "./safety/prompts";
+import { DEFAULT_RULES, type SafetyRules } from "./safety/rules";
 import type { AnswerMode } from "./answer";
 
 export interface PipelineResult {
@@ -53,22 +54,28 @@ function refuse(reason?: string, category?: string): PipelineResult {
   return { text: refuseMessage(), mode: "refused", isSpelling: false, category, reason };
 }
 
-export async function answerQuestion(question: string, deps: PipelineDeps): Promise<PipelineResult> {
+export async function answerQuestion(
+  question: string,
+  deps: PipelineDeps,
+  rules: SafetyRules = DEFAULT_RULES,
+): Promise<PipelineResult> {
   const q = (question ?? "").trim();
   if (!q) return defer("empty", "empty_question");
 
   // --- Gate 0: deterministic rules (hard block; never reaches an LLM) ---
-  const rule = ruleCheck(q);
+  const rule = ruleCheck(q, rules);
   if (rule.decision === "refuse") return refuse(rule.reason, rule.category);
   if (rule.decision === "defer") return defer(q, rule.reason, rule.category);
 
   // --- Spelling: deterministic and safe (only spells the requested word) ---
   const spellWord = detectSpelling(q);
   if (spellWord) {
-    if (containsBlockedContent(spellWord)) return defer(q, "blocked_spell_word");
-    const letters = spellWord.toUpperCase().split("").join(", ");
+    if (containsBlockedContent(spellWord, rules)) return defer(q, "blocked_spell_word");
+    // Periods between letters make the text-to-speech pause, so it's read
+    // slowly — roughly matching the letters appearing one at a time on screen.
+    const letters = spellWord.toUpperCase().split("").join(". ");
     return {
-      text: `"${cap(spellWord)}" is spelled ${letters}. ${cap(spellWord)}!`,
+      text: `Let's spell ${spellWord.toLowerCase()}. ${letters}. That spells ${spellWord.toLowerCase()}!`,
       mode: "answered",
       isSpelling: true,
       spellWord: spellWord.toUpperCase(),
@@ -97,7 +104,7 @@ export async function answerQuestion(question: string, deps: PipelineDeps): Prom
   if (!ans || ans.includes(DEFER_TOKEN)) return defer(q, "model_deferred", cls.category);
 
   // --- Post-check: the generated answer must itself be clean and short ---
-  if (containsBlockedContent(ans)) return defer(q, "answer_tripped_deny", cls.category);
+  if (containsBlockedContent(ans, rules)) return defer(q, "answer_tripped_deny", cls.category);
   const clean = clampSentences(ans);
   if (!clean) return defer(q, "empty_after_clamp", cls.category);
 

--- a/questionbox/server/lib/safety/rules-store.ts
+++ b/questionbox/server/lib/safety/rules-store.ts
@@ -1,0 +1,84 @@
+/**
+ * Loads the editable safety rules from Supabase (so a parent can change them
+ * from the dashboard without a code change). Falls back to DEFAULT_RULES when
+ * Supabase isn't configured, and seeds the table with the defaults the first
+ * time it's found empty. Cached briefly to avoid a DB hit on every question.
+ */
+import { getSupabaseAdmin, isSupabaseConfigured } from "../supabase";
+import { DEFAULT_RULES, type SafetyRules, type TopicRule } from "./rules";
+
+interface RuleRow {
+  kind: "allow" | "deny" | "refuse";
+  rule_key: string;
+  label: string;
+  patterns: string[];
+  enabled: boolean;
+  sort: number;
+}
+
+const CACHE_TTL_MS = 30_000;
+let cache: { rules: SafetyRules; at: number } | null = null;
+
+function rulesToRows(rules: SafetyRules): RuleRow[] {
+  const rows: RuleRow[] = [];
+  const push = (kind: RuleRow["kind"], list: TopicRule[]) =>
+    list.forEach((r, i) =>
+      rows.push({ kind, rule_key: r.id, label: r.label, patterns: r.patterns, enabled: true, sort: i }),
+    );
+  push("allow", rules.allow);
+  push("deny", rules.deny);
+  push("refuse", rules.refuse);
+  return rows;
+}
+
+function rowsToRules(rows: RuleRow[]): SafetyRules {
+  const pick = (kind: RuleRow["kind"]): TopicRule[] =>
+    rows
+      .filter((r) => r.kind === kind && r.enabled)
+      .sort((a, b) => a.sort - b.sort)
+      .map((r) => ({ id: r.rule_key, label: r.label, patterns: r.patterns ?? [] }));
+  return {
+    version: "supabase",
+    allow: pick("allow"),
+    deny: pick("deny"),
+    refuse: pick("refuse"),
+  };
+}
+
+/** Returns the current safety rules, from Supabase if configured else defaults. */
+export async function getRules(): Promise<SafetyRules> {
+  if (!isSupabaseConfigured()) return DEFAULT_RULES;
+
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.rules;
+
+  try {
+    const db = getSupabaseAdmin();
+    const { data, error } = await db.from("topic_rules").select("kind,rule_key,label,patterns,enabled,sort");
+    if (error) throw error;
+
+    let rows = (data ?? []) as RuleRow[];
+    if (rows.length === 0) {
+      // First run: seed the table with the defaults.
+      await db.from("topic_rules").upsert(rulesToRows(DEFAULT_RULES), { onConflict: "kind,rule_key" });
+      rows = rulesToRows(DEFAULT_RULES);
+    }
+
+    const rules = rowsToRules(rows);
+    // Guard against a misconfigured/empty allow list wiping our safety net:
+    // if there are no deny rules, fall back to defaults.
+    if (rules.deny.length === 0) {
+      cache = { rules: DEFAULT_RULES, at: Date.now() };
+      return DEFAULT_RULES;
+    }
+    cache = { rules, at: Date.now() };
+    return rules;
+  } catch (e) {
+    console.error("[rules] load failed, using defaults:", e);
+    return DEFAULT_RULES;
+  }
+}
+
+/** For tests: clear the in-memory cache. */
+export function _clearRulesCache(): void {
+  cache = null;
+}

--- a/questionbox/server/lib/supabase.ts
+++ b/questionbox/server/lib/supabase.ts
@@ -1,0 +1,25 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Server-side Supabase client using the SERVICE ROLE key. This bypasses Row
+ * Level Security and must ONLY ever be used on the server — never shipped to a
+ * browser. The service role key comes from the environment only.
+ */
+
+let admin: SupabaseClient | null = null;
+
+export function isSupabaseConfigured(): boolean {
+  return !!(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+export function getSupabaseAdmin(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Supabase not configured");
+  if (!admin) {
+    admin = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+  return admin;
+}

--- a/questionbox/server/package-lock.json
+++ b/questionbox/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wonderbox-server",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "2.110.9",
         "next": "16.2.12",
         "openai": "6.49.0",
         "react": "19.2.8",
@@ -972,6 +973,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.110.9",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.9.tgz",
+      "integrity": "sha512-XQIWyJfwEUdtzinuLUWPNSJbJKWdCQPqC7dDY45lA1qhX/OzvGPE+4OyPPZVOVWVh4DlPvk5RT2XL6SEAY0MoA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.110.9",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.9.tgz",
+      "integrity": "sha512-iSL6ih4vWK5Myc1lCuDoApfeB3Ov3cZIExvlCuQEZTzyzOKG4SLxVKPrBZG/QzwAjp7TEy0LCd0zZQtE5UAaDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.110.9",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.9.tgz",
+      "integrity": "sha512-YEfUzBMNkDE9OMfjzZnVgJH9h7y+wxxXryrgYk/t3boVtjPPlfwTdWRx8YkihuIbl4zxzdG4I0yiS4nd4Lmj8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.110.9",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.9.tgz",
+      "integrity": "sha512-XHau+5jIOEAtS9hNiSrL4/2SXSt0EApChsj+f2VJL2mL+eicpUYLkANBu+5awFLIjXGOkys+ClYQ7Dg/3UTHcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.110.9",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.9.tgz",
+      "integrity": "sha512-UmyL+SB4cOBsejAaJ8LnLIm31585shJtnTezCCLMHyo2AauoH13sKJqPllf/8HMcGYqd0a4kHrA5t2nz+MSARA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.110.9",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.9.tgz",
+      "integrity": "sha512-C8UVe+x6hymwiLdJntQCm9zMD5+40tWF6j+17Z6g8NJnBAWEiuM9wXYAqgDzGAQF6oqrkHddmnZwWZZtEp0zeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.110.9",
+        "@supabase/functions-js": "2.110.9",
+        "@supabase/postgrest-js": "2.110.9",
+        "@supabase/realtime-js": "2.110.9",
+        "@supabase/storage-js": "2.110.9"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1300,6 +1385,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/lightningcss": {

--- a/questionbox/server/package.json
+++ b/questionbox/server/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@supabase/supabase-js": "2.110.9",
     "next": "16.2.12",
     "openai": "6.49.0",
     "react": "19.2.8",

--- a/questionbox/server/supabase/schema.sql
+++ b/questionbox/server/supabase/schema.sql
@@ -1,0 +1,65 @@
+-- WonderBox database schema (run this in the Supabase SQL editor).
+--
+-- Two tables:
+--   interactions  — the log of what was asked/answered (TEXT ONLY, never audio)
+--   topic_rules   — the editable allow/deny/refuse safety rules
+--
+-- Row Level Security is ON for both, with NO permissive policies: only the
+-- service role (used by the server) can read/write. The parent dashboard reads
+-- via the server using the service role after authenticating the parent, so we
+-- never expose this data to the anon/public key.
+
+-- ---------------------------------------------------------------------------
+-- interactions
+-- ---------------------------------------------------------------------------
+create table if not exists public.interactions (
+  id          uuid primary key default gen_random_uuid(),
+  created_at  timestamptz not null default now(),
+  question    text,
+  answer      text,
+  mode        text not null check (mode in ('answered', 'deferred', 'refused')),
+  category    text,
+  reason      text,
+  is_spelling boolean not null default false,
+  spell_word  text,
+  latency_ms  integer,
+  device_id   text
+);
+
+create index if not exists interactions_created_at_idx
+  on public.interactions (created_at desc);
+
+alter table public.interactions enable row level security;
+-- (no policies => only the service role can access)
+
+-- ---------------------------------------------------------------------------
+-- topic_rules (editable safety configuration)
+-- ---------------------------------------------------------------------------
+create table if not exists public.topic_rules (
+  id         uuid primary key default gen_random_uuid(),
+  kind       text not null check (kind in ('allow', 'deny', 'refuse')),
+  rule_key   text not null,
+  label      text not null,
+  patterns   jsonb not null default '[]'::jsonb,  -- array of regex source strings
+  enabled    boolean not null default true,
+  sort       integer not null default 0,
+  updated_at timestamptz not null default now(),
+  unique (kind, rule_key)
+);
+
+alter table public.topic_rules enable row level security;
+-- (no policies => only the service role can access)
+
+-- Keep updated_at fresh on edits.
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists topic_rules_set_updated_at on public.topic_rules;
+create trigger topic_rules_set_updated_at
+  before update on public.topic_rules
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## WonderBox — Stage 5 (Supabase logging + editable rules)

Adds interaction logging and moves the safety rules into editable Supabase config, plus a spelling-audio polish.

> Stacked on the Stage 4 branch so this PR's diff is only the Stage 5 changes.

### Logging — text only, never audio
Every interaction is logged to Supabase: timestamp, transcribed question, answer, `mode` (answered/deferred/refused), `category`, `reason`, `is_spelling`, `spell_word`, and latency. **Audio is never logged or stored.** Logging is best-effort (a failure never breaks a child's answer) and is skipped entirely when Supabase isn't configured.

### Editable safety rules
- `supabase/schema.sql`: `interactions` + `topic_rules` tables, **RLS on with no public policies** (only the server's service role can read/write), an `updated_at` trigger, and an index.
- `lib/safety/rules-store.ts`: loads the rules from `topic_rules`, **seeds the defaults on first run**, caches for 30s, and **falls back to `DEFAULT_RULES`** on any error — and also if the loaded deny-list is empty, so the safety net can never be misconfigured away.
- Dynamic rules are threaded through the pipeline and both LLM gates, so edits take effect without a code change.

### Spelling polish
Spelling answers are now spoken **slowly** (letters separated by pauses: "D. O. G.") to line up with the device's letter-by-letter on-screen reveal (already built in the firmware).

### Security
- `SUPABASE_SERVICE_ROLE_KEY` is server-only (never sent to a browser). RLS default-deny; the dashboard (Stage 6) will read via the server after authenticating the parent.
- Audio still never stored anywhere.

### Tests / verification
- New tests: rules-store fallback when unconfigured; logging is a safe no-op when unconfigured. **81 tests pass**, `typecheck` and `next build` green.
- Docs pulled via **Context7** (supabase-js).

### What you need to set (on Vercel)
Create a Supabase project, run `supabase/schema.sql`, then add `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY`.

_No firmware changes this stage (spelling-on-screen shipped earlier). Draft for review before Stage 6 (parent dashboard)._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

