### PR TITLE
WonderBox Stage 6 — private parent dashboard (log, search, rules editor)

### DIFF
--- a/questionbox/server/.env.example
+++ b/questionbox/server/.env.example
@@ -34,6 +34,13 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# --- Stage 6 (parent dashboard; NEEDED NOW for the dashboard) ------------
+# The dashboard is protected by a single password you choose.
+DASHBOARD_PASSWORD=
+# Optional: a random secret used to sign the session cookie
+# (openssl rand -hex 32). If unset, it is derived from DASHBOARD_PASSWORD.
+DASHBOARD_SESSION_SECRET=
+
 # --- Stage 7 (daily digest email) ----------------------------------------
 # RESEND_API_KEY=
 # DIGEST_TO_EMAIL=

--- a/questionbox/server/README.md
+++ b/questionbox/server/README.md
@@ -74,6 +74,23 @@ header `Authorization: Bearer <DEVICE_TOKEN>`.
 We return audio as the body + text in headers so the microcontroller doesn't
 have to parse JSON or decode base64.
 
+## Parent dashboard (Stage 6)
+
+Private, password-protected pages for you only:
+
+- **`/login`** — sign in with your `DASHBOARD_PASSWORD`.
+- **`/dashboard`** — today's summary (answered / deferred / refused + topics).
+- **`/dashboard/log`** — the full question log, pick any day, search text.
+- **`/dashboard/rules`** — edit the approved/blocked topic rules (add, edit
+  patterns, enable/disable, delete) — changes take effect within ~30s.
+
+**Auth:** a single password (`DASHBOARD_PASSWORD`) with a signed, HttpOnly,
+Secure session cookie — no email/SMTP needed. Set `DASHBOARD_PASSWORD` (and
+optionally `DASHBOARD_SESSION_SECRET`) in your env. Dashboard data is read on the
+server with the Supabase service role *after* the session check, so the data is
+never exposed to the browser via the public key. (Can be upgraded to
+Supabase-Auth magic links locked to your email if you prefer.)
+
 ## Run it locally
 
 ```bash

--- a/questionbox/server/__tests__/session.test.ts
+++ b/questionbox/server/__tests__/session.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  checkPassword,
+  createSessionToken,
+  verifySessionToken,
+  SESSION_TTL_SECONDS,
+} from "@/lib/auth/session";
+
+beforeEach(() => {
+  process.env.DASHBOARD_PASSWORD = "correct horse battery staple";
+  process.env.DASHBOARD_SESSION_SECRET = "unit-test-secret";
+});
+
+describe("dashboard password", () => {
+  it("accepts the right password and rejects wrong ones", () => {
+    expect(checkPassword("correct horse battery staple")).toBe(true);
+    expect(checkPassword("wrong")).toBe(false);
+    expect(checkPassword("")).toBe(false);
+  });
+});
+
+describe("session tokens", () => {
+  it("verifies a freshly minted token", () => {
+    const t = createSessionToken();
+    expect(verifySessionToken(t)).toBe(true);
+  });
+
+  it("rejects a tampered token", () => {
+    const t = createSessionToken();
+    expect(verifySessionToken(t + "x")).toBe(false);
+    expect(verifySessionToken("garbage")).toBe(false);
+    expect(verifySessionToken(undefined)).toBe(false);
+  });
+
+  it("rejects an expired token", () => {
+    const past = Date.now() - (SESSION_TTL_SECONDS + 60) * 1000;
+    const t = createSessionToken(past);
+    expect(verifySessionToken(t)).toBe(false);
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const t = createSessionToken();
+    process.env.DASHBOARD_SESSION_SECRET = "a-different-secret";
+    expect(verifySessionToken(t)).toBe(false);
+  });
+});

--- a/questionbox/server/app/dashboard/layout.tsx
+++ b/questionbox/server/app/dashboard/layout.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { requireSession } from "@/lib/auth/guard";
+import { logoutAction } from "@/app/login/actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  await requireSession();
+
+  return (
+    <div className="dash">
+      <header className="dash-header">
+        <div className="dash-brand">
+          <span className="dot" aria-hidden />
+          WonderBox
+        </div>
+        <nav className="dash-nav">
+          <Link href="/dashboard">Summary</Link>
+          <Link href="/dashboard/log">Question log</Link>
+          <Link href="/dashboard/rules">Topic rules</Link>
+        </nav>
+        <form action={logoutAction}>
+          <button className="btn-ghost" type="submit">Sign out</button>
+        </form>
+      </header>
+      <main className="dash-main">{children}</main>
+    </div>
+  );
+}

--- a/questionbox/server/app/dashboard/log/page.tsx
+++ b/questionbox/server/app/dashboard/log/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { getInteractionsByDay, todayStr, type Interaction } from "@/lib/dashboard-data";
+import { isSupabaseConfigured } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+function shiftDay(date: string, days: number): string {
+  const d = new Date(`${date}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function timeOf(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+const MODE_LABEL: Record<Interaction["mode"], string> = {
+  answered: "Answered",
+  deferred: "Sent to grown-up",
+  refused: "Declined",
+};
+
+export default async function LogPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string; q?: string }>;
+}) {
+  const { date: dateParam, q } = await searchParams;
+  const date = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : todayStr();
+  const configured = isSupabaseConfigured();
+  const rows = configured ? await getInteractionsByDay(date, q) : [];
+
+  return (
+    <section>
+      <h1>Question log</h1>
+
+      <form className="filters" method="get">
+        <label>
+          Day
+          <input className="input" type="date" name="date" defaultValue={date} />
+        </label>
+        <label className="grow">
+          Search
+          <input className="input" type="search" name="q" placeholder="search questions & answers" defaultValue={q ?? ""} />
+        </label>
+        <button className="btn" type="submit">Go</button>
+      </form>
+
+      <div className="daynav">
+        <Link href={`/dashboard/log?date=${shiftDay(date, -1)}`}>← Previous day</Link>
+        <span>{date}</span>
+        <Link href={`/dashboard/log?date=${shiftDay(date, 1)}`}>Next day →</Link>
+      </div>
+
+      {!configured && <p className="alert">Supabase isn&apos;t configured yet.</p>}
+
+      {configured && rows.length === 0 && <p className="muted">No questions{q ? " match your search" : ""} on this day.</p>}
+
+      <ul className="log">
+        {rows.map((r) => (
+          <li key={r.id} className={`log-item mode-${r.mode}`}>
+            <div className="log-top">
+              <span className="time">{timeOf(r.created_at)}</span>
+              <span className={`badge badge-${r.mode}`}>{MODE_LABEL[r.mode]}</span>
+              {r.category && <span className="cat">{r.category}</span>}
+              {r.is_spelling && <span className="cat">spelling</span>}
+            </div>
+            <div className="q">{r.question || <em>(no transcript)</em>}</div>
+            <div className="a">{r.answer}</div>
+            {r.reason && r.mode !== "answered" && <div className="why">why: {r.reason}</div>}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/questionbox/server/app/dashboard/page.tsx
+++ b/questionbox/server/app/dashboard/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { getDailySummary, todayStr } from "@/lib/dashboard-data";
+import { isSupabaseConfigured } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardHome() {
+  const configured = isSupabaseConfigured();
+  const today = todayStr();
+  const summary = configured ? await getDailySummary(today) : null;
+
+  return (
+    <section>
+      <h1>Today</h1>
+
+      {!configured && (
+        <p className="alert">
+          Supabase isn&apos;t configured yet, so there&apos;s nothing to show.
+          Add the Supabase environment variables and run <code>supabase/schema.sql</code>.
+        </p>
+      )}
+
+      {summary && (
+        <>
+          <p className="lead">{summary.friendly}</p>
+
+          <div className="stats">
+            <div className="stat stat-answered">
+              <div className="stat-num">{summary.answered}</div>
+              <div className="stat-label">Answered</div>
+            </div>
+            <div className="stat stat-deferred">
+              <div className="stat-num">{summary.deferred}</div>
+              <div className="stat-label">Sent to a grown-up</div>
+            </div>
+            <div className="stat stat-refused">
+              <div className="stat-num">{summary.refused}</div>
+              <div className="stat-label">Declined</div>
+            </div>
+          </div>
+
+          {summary.topics.length > 0 && (
+            <div className="topics">
+              <h2>Topics they explored</h2>
+              <ul className="chips">
+                {summary.topics.map((t) => (
+                  <li key={t.label} className="chip">
+                    {t.label} <span className="chip-count">{t.count}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <p>
+            <Link className="btn" href={`/dashboard/log?date=${today}`}>
+              See today&apos;s questions
+            </Link>
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/questionbox/server/app/dashboard/rules/actions.ts
+++ b/questionbox/server/app/dashboard/rules/actions.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireSession } from "@/lib/auth/guard";
+import { getSupabaseAdmin, isSupabaseConfigured } from "@/lib/supabase";
+import { _clearRulesCache } from "@/lib/safety/rules-store";
+
+function parsePatterns(raw: string): string[] {
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function afterChange() {
+  _clearRulesCache();
+  revalidatePath("/dashboard/rules");
+}
+
+export async function saveRuleAction(formData: FormData): Promise<void> {
+  await requireSession();
+  if (!isSupabaseConfigured()) return;
+  const id = String(formData.get("id") ?? "");
+  const label = String(formData.get("label") ?? "").trim();
+  const enabled = formData.get("enabled") === "on";
+  const patterns = parsePatterns(String(formData.get("patterns") ?? ""));
+  if (!id) return;
+
+  const db = getSupabaseAdmin();
+  await db.from("topic_rules").update({ label, enabled, patterns }).eq("id", id);
+  await afterChange();
+}
+
+export async function addRuleAction(formData: FormData): Promise<void> {
+  await requireSession();
+  if (!isSupabaseConfigured()) return;
+  const kind = String(formData.get("kind") ?? "");
+  const rule_key = String(formData.get("rule_key") ?? "").trim().toLowerCase().replace(/\s+/g, "-");
+  const label = String(formData.get("label") ?? "").trim();
+  const patterns = parsePatterns(String(formData.get("patterns") ?? ""));
+  if (!["allow", "deny", "refuse"].includes(kind) || !rule_key || !label) return;
+
+  const db = getSupabaseAdmin();
+  await db.from("topic_rules").upsert(
+    { kind, rule_key, label, patterns, enabled: true, sort: 999 },
+    { onConflict: "kind,rule_key" },
+  );
+  await afterChange();
+}
+
+export async function deleteRuleAction(formData: FormData): Promise<void> {
+  await requireSession();
+  if (!isSupabaseConfigured()) return;
+  const id = String(formData.get("id") ?? "");
+  if (!id) return;
+  const db = getSupabaseAdmin();
+  await db.from("topic_rules").delete().eq("id", id);
+  await afterChange();
+}

--- a/questionbox/server/app/dashboard/rules/page.tsx
+++ b/questionbox/server/app/dashboard/rules/page.tsx
@@ -1,0 +1,103 @@
+import { ensureRulesSeeded } from "@/lib/safety/rules-store";
+import { getAllTopicRules, type TopicRuleRow } from "@/lib/dashboard-data";
+import { isSupabaseConfigured } from "@/lib/supabase";
+import { addRuleAction, deleteRuleAction, saveRuleAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+const KIND_TITLE: Record<TopicRuleRow["kind"], string> = {
+  allow: "Allowed topics (answered)",
+  deny: "Deferred topics (sent to a grown-up)",
+  refuse: "Refused (rule-change attempts)",
+};
+
+const KIND_HELP: Record<TopicRuleRow["kind"], string> = {
+  allow: "Questions matching these may be answered (still checked by the AI safety gates).",
+  deny: "Questions matching these are always sent to a parent — never answered.",
+  refuse: "Attempts to change the rules or jailbreak the box.",
+};
+
+function RuleCard({ rule }: { rule: TopicRuleRow }) {
+  return (
+    <div className={`rule ${rule.enabled ? "" : "rule-off"}`}>
+      <form action={saveRuleAction} className="rule-form">
+        <input type="hidden" name="id" value={rule.id} />
+        <div className="rule-head">
+          <input className="input rule-label" name="label" defaultValue={rule.label} aria-label="Topic label" />
+          <label className="switch">
+            <input type="checkbox" name="enabled" defaultChecked={rule.enabled} /> on
+          </label>
+        </div>
+        <textarea
+          className="input mono"
+          name="patterns"
+          rows={Math.min(8, Math.max(3, rule.patterns.length))}
+          defaultValue={rule.patterns.join("\n")}
+          aria-label="Patterns, one per line"
+        />
+        <div className="rule-actions">
+          <button className="btn" type="submit">Save</button>
+        </div>
+      </form>
+      <form action={deleteRuleAction}>
+        <input type="hidden" name="id" value={rule.id} />
+        <button className="btn-ghost danger" type="submit">Delete</button>
+      </form>
+    </div>
+  );
+}
+
+export default async function RulesPage() {
+  const configured = isSupabaseConfigured();
+  if (configured) {
+    try {
+      await ensureRulesSeeded();
+    } catch {
+      /* ignore; page still renders */
+    }
+  }
+  const rules = configured ? await getAllTopicRules() : [];
+  const byKind = (k: TopicRuleRow["kind"]) => rules.filter((r) => r.kind === k);
+
+  return (
+    <section>
+      <h1>Topic rules</h1>
+      <p className="muted">
+        Edit what WonderBox will answer. One pattern per line — each is a small
+        text pattern (regular expression) matched against the question. When in
+        doubt, WonderBox defers to you.
+      </p>
+
+      {!configured && (
+        <p className="alert">
+          Supabase isn&apos;t configured yet, so rules can&apos;t be edited here.
+          Until then, the built-in defaults are used.
+        </p>
+      )}
+
+      {configured &&
+        (["allow", "deny", "refuse"] as const).map((kind) => (
+          <div key={kind} className="rule-group">
+            <h2>{KIND_TITLE[kind]}</h2>
+            <p className="muted">{KIND_HELP[kind]}</p>
+            <div className="rule-grid">
+              {byKind(kind).map((r) => (
+                <RuleCard key={r.id} rule={r} />
+              ))}
+            </div>
+
+            <details className="add">
+              <summary>+ Add a {kind} topic</summary>
+              <form action={addRuleAction} className="rule-form">
+                <input type="hidden" name="kind" value={kind} />
+                <input className="input" name="rule_key" placeholder="short id, e.g. weather" required />
+                <input className="input" name="label" placeholder="label, e.g. weather" required />
+                <textarea className="input mono" name="patterns" rows={3} placeholder="one pattern per line" />
+                <button className="btn" type="submit">Add</button>
+              </form>
+            </details>
+          </div>
+        ))}
+    </section>
+  );
+}

--- a/questionbox/server/app/globals.css
+++ b/questionbox/server/app/globals.css
@@ -86,3 +86,316 @@ p {
   color: #8a8fa3;
   font-size: 14px;
 }
+
+/* ---------- shared form bits ---------- */
+.input {
+  width: 100%;
+  padding: 12px 14px;
+  margin: 8px 0;
+  border: 1px solid #e6ddcd;
+  border-radius: 14px;
+  font-size: 16px;
+  background: #fffdf9;
+  color: var(--ink);
+}
+.mono {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+.btn {
+  display: inline-block;
+  padding: 11px 20px;
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-ghost {
+  padding: 9px 16px;
+  border: 1px solid #e6ddcd;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 14px;
+}
+.btn-ghost.danger {
+  color: #c0392b;
+  border-color: #f0c9c2;
+}
+.alert {
+  background: #fff2ee;
+  border: 1px solid #ffd3c7;
+  color: #b23b1e;
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+}
+code {
+  background: #f2ead9;
+  border-radius: 6px;
+  padding: 1px 6px;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+/* ---------- dashboard shell ---------- */
+.dash {
+  min-height: 100vh;
+}
+.dash-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 24px;
+  background: #fffaf2;
+  border-bottom: 1px solid #efe6d5;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+.dash-brand {
+  font-weight: 700;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.dash-brand .dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.dash-nav {
+  display: flex;
+  gap: 18px;
+  margin-left: 8px;
+  flex: 1;
+}
+.dash-nav a {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 15px;
+  opacity: 0.8;
+}
+.dash-nav a:hover {
+  opacity: 1;
+}
+.dash-main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 28px 24px 80px;
+}
+.dash-main h1 {
+  font-size: 28px;
+  text-align: left;
+}
+.dash-main h2 {
+  font-size: 19px;
+  margin-top: 28px;
+}
+.lead {
+  font-size: 18px;
+}
+
+/* ---------- summary stats ---------- */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  margin: 18px 0;
+}
+.stat {
+  background: #fffaf2;
+  border: 1px solid #efe6d5;
+  border-radius: 18px;
+  padding: 18px;
+  text-align: center;
+}
+.stat-num {
+  font-size: 34px;
+  font-weight: 800;
+}
+.stat-label {
+  font-size: 13px;
+  color: #8a8fa3;
+}
+.stat-answered .stat-num {
+  color: #2e9e5b;
+}
+.stat-deferred .stat-num {
+  color: #d98324;
+}
+.stat-refused .stat-num {
+  color: #c0392b;
+}
+.chips {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.chip {
+  background: #fff3e0;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 14px;
+}
+.chip-count {
+  color: #8a8fa3;
+  font-weight: 700;
+}
+
+/* ---------- log ---------- */
+.filters {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+.filters label {
+  font-size: 13px;
+  color: #8a8fa3;
+  display: flex;
+  flex-direction: column;
+}
+.filters .grow {
+  flex: 1;
+  min-width: 180px;
+}
+.daynav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 16px 0;
+  font-size: 14px;
+}
+.daynav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+.log {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.log-item {
+  background: #fffaf2;
+  border: 1px solid #efe6d5;
+  border-left: 5px solid #cfd6e0;
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.log-item.mode-answered {
+  border-left-color: #2e9e5b;
+}
+.log-item.mode-deferred {
+  border-left-color: #d98324;
+}
+.log-item.mode-refused {
+  border-left-color: #c0392b;
+}
+.log-top {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+.time {
+  font-size: 12px;
+  color: #8a8fa3;
+}
+.badge {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: #fff;
+}
+.badge-answered {
+  background: #2e9e5b;
+}
+.badge-deferred {
+  background: #d98324;
+}
+.badge-refused {
+  background: #c0392b;
+}
+.cat {
+  font-size: 12px;
+  color: #8a8fa3;
+  background: #f2ead9;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.log-item .q {
+  font-weight: 700;
+}
+.log-item .a {
+  margin-top: 4px;
+}
+.log-item .why {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #a2895f;
+}
+
+/* ---------- rules editor ---------- */
+.rule-group {
+  margin-bottom: 34px;
+}
+.rule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+.rule {
+  background: #fffaf2;
+  border: 1px solid #efe6d5;
+  border-radius: 16px;
+  padding: 14px;
+}
+.rule-off {
+  opacity: 0.55;
+}
+.rule-head {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.rule-label {
+  margin: 0;
+}
+.switch {
+  font-size: 13px;
+  color: #8a8fa3;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.rule-actions {
+  margin-top: 8px;
+}
+.add {
+  margin-top: 14px;
+}
+.add summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-weight: 600;
+}

--- a/questionbox/server/app/login/actions.ts
+++ b/questionbox/server/app/login/actions.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
+  checkPassword,
+  createSessionToken,
+  isDashboardConfigured,
+} from "@/lib/auth/session";
+
+export async function loginAction(formData: FormData): Promise<void> {
+  if (!isDashboardConfigured()) redirect("/login?error=unconfigured");
+
+  const password = String(formData.get("password") ?? "");
+  if (!checkPassword(password)) redirect("/login?error=1");
+
+  const store = await cookies();
+  store.set(SESSION_COOKIE, createSessionToken(), {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS,
+  });
+  redirect("/dashboard");
+}
+
+export async function logoutAction(): Promise<void> {
+  const store = await cookies();
+  store.delete(SESSION_COOKIE);
+  redirect("/login");
+}

--- a/questionbox/server/app/login/page.tsx
+++ b/questionbox/server/app/login/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import { loginAction } from "./actions";
+import { hasSession } from "@/lib/auth/guard";
+import { isDashboardConfigured } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  if (await hasSession()) redirect("/dashboard");
+  const { error } = await searchParams;
+  const configured = isDashboardConfigured();
+
+  return (
+    <main className="wrap">
+      <form className="card" action={loginAction}>
+        <div className="logo" aria-hidden>
+          <span className="eye" />
+          <span className="eye" />
+          <span className="mouth" />
+        </div>
+        <h1>WonderBox</h1>
+        <p className="muted">Parent dashboard — please sign in.</p>
+
+        {!configured && (
+          <p className="alert">
+            Set <code>DASHBOARD_PASSWORD</code> in your environment to enable the
+            dashboard.
+          </p>
+        )}
+        {error === "1" && <p className="alert">Incorrect password. Try again.</p>}
+
+        <input
+          className="input"
+          type="password"
+          name="password"
+          placeholder="Password"
+          autoComplete="current-password"
+          required
+          disabled={!configured}
+        />
+        <button className="btn" type="submit" disabled={!configured}>
+          Sign in
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/questionbox/server/lib/auth/guard.ts
+++ b/questionbox/server/lib/auth/guard.ts
@@ -1,0 +1,14 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { SESSION_COOKIE, verifySessionToken } from "./session";
+
+/** Returns true if the current request has a valid dashboard session. */
+export async function hasSession(): Promise<boolean> {
+  const store = await cookies();
+  return verifySessionToken(store.get(SESSION_COOKIE)?.value);
+}
+
+/** Use at the top of any dashboard page / action. Redirects to /login if not authed. */
+export async function requireSession(): Promise<void> {
+  if (!(await hasSession())) redirect("/login");
+}

--- a/questionbox/server/lib/auth/session.ts
+++ b/questionbox/server/lib/auth/session.ts
@@ -1,0 +1,72 @@
+import { createHmac, createHash, timingSafeEqual } from "node:crypto";
+
+/**
+ * Minimal, dependency-free session for the single-parent dashboard.
+ *
+ * Login is a single password (DASHBOARD_PASSWORD). On success we set an
+ * HttpOnly, Secure, SameSite=Lax cookie holding an HMAC-signed token with an
+ * expiry. No user database, no third-party auth — private and simple.
+ */
+
+export const SESSION_COOKIE = "wb_session";
+export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+export function isDashboardConfigured(): boolean {
+  return !!process.env.DASHBOARD_PASSWORD;
+}
+
+function getSecret(): string {
+  // Prefer an explicit secret; otherwise derive one from the password so
+  // sessions are still signed. Changing the password invalidates old sessions.
+  const explicit = process.env.DASHBOARD_SESSION_SECRET;
+  if (explicit && explicit.length > 0) return explicit;
+  const pw = process.env.DASHBOARD_PASSWORD ?? "";
+  return createHash("sha256").update(`wb-session:${pw}`).digest("hex");
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function sign(payload: string): string {
+  return b64url(createHmac("sha256", getSecret()).update(payload).digest());
+}
+
+/** True if `password` matches DASHBOARD_PASSWORD (constant-time). */
+export function checkPassword(password: string): boolean {
+  const expected = process.env.DASHBOARD_PASSWORD;
+  if (!expected) return false;
+  const a = Buffer.from(password);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    timingSafeEqual(a, a);
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+export function createSessionToken(now = Date.now()): string {
+  const exp = Math.floor(now / 1000) + SESSION_TTL_SECONDS;
+  const payload = b64url(Buffer.from(JSON.stringify({ exp })));
+  return `${payload}.${sign(payload)}`;
+}
+
+export function verifySessionToken(token: string | undefined, now = Date.now()): boolean {
+  if (!token) return false;
+  const dot = token.lastIndexOf(".");
+  if (dot <= 0) return false;
+  const payload = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+
+  const expected = sign(payload);
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return false;
+
+  try {
+    const json = JSON.parse(Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString());
+    return typeof json.exp === "number" && json.exp > Math.floor(now / 1000);
+  } catch {
+    return false;
+  }
+}

--- a/questionbox/server/lib/dashboard-data.ts
+++ b/questionbox/server/lib/dashboard-data.ts
@@ -1,0 +1,124 @@
+import { getSupabaseAdmin, isSupabaseConfigured } from "./supabase";
+import type { AnswerMode } from "./answer";
+
+export interface Interaction {
+  id: string;
+  created_at: string;
+  question: string | null;
+  answer: string | null;
+  mode: AnswerMode;
+  category: string | null;
+  reason: string | null;
+  is_spelling: boolean;
+  spell_word: string | null;
+  latency_ms: number | null;
+}
+
+export interface TopicRuleRow {
+  id: string;
+  kind: "allow" | "deny" | "refuse";
+  rule_key: string;
+  label: string;
+  patterns: string[];
+  enabled: boolean;
+  sort: number;
+}
+
+export interface DailySummary {
+  date: string;
+  total: number;
+  answered: number;
+  deferred: number;
+  refused: number;
+  topics: { label: string; count: number }[];
+  friendly: string;
+}
+
+/** [start, end) ISO bounds for a YYYY-MM-DD day in the given tz offset (UTC). */
+function dayBounds(date: string): { start: string; end: string } {
+  const start = new Date(`${date}T00:00:00.000Z`);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function getInteractionsByDay(date: string, q?: string): Promise<Interaction[]> {
+  if (!isSupabaseConfigured()) return [];
+  const db = getSupabaseAdmin();
+  const { start, end } = dayBounds(date);
+  let query = db
+    .from("interactions")
+    .select("*")
+    .gte("created_at", start)
+    .lt("created_at", end)
+    .order("created_at", { ascending: false })
+    .limit(500);
+  if (q && q.trim()) {
+    const term = q.trim().replace(/[%,]/g, " ");
+    query = query.or(`question.ilike.%${term}%,answer.ilike.%${term}%`);
+  }
+  const { data, error } = await query;
+  if (error) {
+    console.error("[dashboard] getInteractionsByDay:", error);
+    return [];
+  }
+  return (data ?? []) as Interaction[];
+}
+
+export async function getDailySummary(date: string): Promise<DailySummary> {
+  const rows = await getInteractionsByDay(date);
+  const summary: DailySummary = {
+    date,
+    total: rows.length,
+    answered: rows.filter((r) => r.mode === "answered").length,
+    deferred: rows.filter((r) => r.mode === "deferred").length,
+    refused: rows.filter((r) => r.mode === "refused").length,
+    topics: [],
+    friendly: "",
+  };
+
+  const counts = new Map<string, number>();
+  for (const r of rows) {
+    if (r.mode === "answered" && r.category) {
+      counts.set(r.category, (counts.get(r.category) ?? 0) + 1);
+    }
+  }
+  summary.topics = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 6);
+
+  summary.friendly = buildFriendly(summary);
+  return summary;
+}
+
+function buildFriendly(s: DailySummary): string {
+  if (s.total === 0) return "No questions yet today.";
+  const topicList = s.topics.map((t) => t.label).slice(0, 3);
+  const topics = topicList.length
+    ? ` about ${topicList.join(", ")}`
+    : "";
+  const parts = [`Today there were ${s.total} question${s.total === 1 ? "" : "s"}`];
+  if (s.answered) parts.push(`answered ${s.answered}${topics}`);
+  if (s.deferred) parts.push(`gently sent ${s.deferred} to a grown-up`);
+  if (s.refused) parts.push(`declined ${s.refused}`);
+  return parts.join(", ") + ".";
+}
+
+export async function getAllTopicRules(): Promise<TopicRuleRow[]> {
+  if (!isSupabaseConfigured()) return [];
+  const db = getSupabaseAdmin();
+  const { data, error } = await db
+    .from("topic_rules")
+    .select("*")
+    .order("kind", { ascending: true })
+    .order("sort", { ascending: true });
+  if (error) {
+    console.error("[dashboard] getAllTopicRules:", error);
+    return [];
+  }
+  return (data ?? []) as TopicRuleRow[];
+}

--- a/questionbox/server/lib/safety/rules-store.ts
+++ b/questionbox/server/lib/safety/rules-store.ts
@@ -19,7 +19,7 @@ interface RuleRow {
 const CACHE_TTL_MS = 30_000;
 let cache: { rules: SafetyRules; at: number } | null = null;
 
-function rulesToRows(rules: SafetyRules): RuleRow[] {
+export function rulesToRows(rules: SafetyRules): RuleRow[] {
   const rows: RuleRow[] = [];
   const push = (kind: RuleRow["kind"], list: TopicRule[]) =>
     list.forEach((r, i) =>
@@ -78,7 +78,19 @@ export async function getRules(): Promise<SafetyRules> {
   }
 }
 
-/** For tests: clear the in-memory cache. */
+/** Seeds the topic_rules table with the defaults if it is empty. Safe to call
+ *  repeatedly. Used by the dashboard so the editor is populated on first visit. */
+export async function ensureRulesSeeded(): Promise<void> {
+  if (!isSupabaseConfigured()) return;
+  const db = getSupabaseAdmin();
+  const { count, error } = await db.from("topic_rules").select("id", { count: "exact", head: true });
+  if (error) throw error;
+  if ((count ?? 0) === 0) {
+    await db.from("topic_rules").upsert(rulesToRows(DEFAULT_RULES), { onConflict: "kind,rule_key" });
+  }
+}
+
+/** Invalidate the in-memory cache after a rules edit (or in tests). */
 export function _clearRulesCache(): void {
   cache = null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## WonderBox — Stage 6 (parent dashboard)

A private, authenticated dashboard for the parent only.

> Stacked on the Stage 5 branch so this PR's diff is only the Stage 6 changes.

### Auth (simple + private)
- Single-password login (`DASHBOARD_PASSWORD`, constant-time check) with a **signed, HttpOnly, Secure, SameSite=Lax session cookie** (HMAC + expiry). No email/SMTP, no extra dependencies.
- `requireSession()` guards the dashboard layout and every mutating server action.
- Dashboard data is read on the **server with the Supabase service role, only after the session check** — never exposed to the browser via the public key.
- (Notes an easy upgrade path to Supabase-Auth magic links locked to your email, if you'd rather.)

### Pages
- **`/login`** — password sign-in (shows a hint if `DASHBOARD_PASSWORD` isn't set).
- **`/dashboard`** — today's summary: answered / deferred / refused counts, topic chips, and a friendly one-liner.
- **`/dashboard/log`** — full question log; pick any day, prev/next nav, text search across questions & answers, with mode badges + the "why" for deferrals. **Text only.**
- **`/dashboard/rules`** — edit the approved/blocked/refused topic rules: change labels & patterns, enable/disable, add, delete. Changes take effect within ~30s (rules cache is invalidated on save). Seeds the defaults on first visit.

### Verification
- Tests: session sign/verify + password check. **86 tests pass**; `typecheck` and `next build` green (routes: `/login`, `/dashboard`, `/dashboard/log`, `/dashboard/rules`).

### What you need to set (on Vercel)
- `DASHBOARD_PASSWORD` (your choice) and optionally `DASHBOARD_SESSION_SECRET` (`openssl rand -hex 32`). Requires the Supabase env from Stage 5 for data.

_Draft for review before Stage 7 (daily digest email)._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

