### PR TITLE
WonderBox Stage 7 — daily digest (Vercel cron + Resend email)

### DIFF
--- a/questionbox/server/.env.example
+++ b/questionbox/server/.env.example
@@ -41,7 +41,22 @@ DASHBOARD_PASSWORD=
 # (openssl rand -hex 32). If unset, it is derived from DASHBOARD_PASSWORD.
 DASHBOARD_SESSION_SECRET=
 
-# --- Stage 7 (daily digest email) ----------------------------------------
-# RESEND_API_KEY=
-# DIGEST_TO_EMAIL=
-# DIGEST_FROM_EMAIL=
+# --- Stage 7 (daily digest; NEEDED NOW for the digest) -------------------
+# Secret that protects the cron endpoint. Vercel auto-sends it as a Bearer
+# token to /api/cron/digest when set here. Generate: openssl rand -hex 32
+CRON_SECRET=
+
+# Email via Resend (default provider). Get a key at https://resend.com
+RESEND_API_KEY=
+DIGEST_TO_EMAIL=
+# From address. Defaults to Resend's shared sender until you verify a domain.
+# DIGEST_FROM_EMAIL=WonderBox <onboarding@resend.dev>
+# Optional: personalize the note, e.g. DIGEST_CHILD_NAME=Gus
+# DIGEST_CHILD_NAME=
+
+# Optional: switch the digest to SMS via Twilio instead of email
+# DIGEST_PROVIDER=sms
+# TWILIO_ACCOUNT_SID=
+# TWILIO_AUTH_TOKEN=
+# TWILIO_FROM=+1XXXXXXXXXX
+# DIGEST_TO_SMS=+1XXXXXXXXXX

--- a/questionbox/server/README.md
+++ b/questionbox/server/README.md
@@ -91,6 +91,25 @@ server with the Supabase service role *after* the session check, so the data is
 never exposed to the browser via the public key. (Can be upgraded to
 Supabase-Auth magic links locked to your email if you prefer.)
 
+## Daily digest (Stage 7)
+
+Once a day, a **Vercel Cron** job (`vercel.json` → `/api/cron/digest`, default
+13:00 UTC) summarizes the previous day's questions into a short, friendly note
+("On Sunday, the kids asked WonderBox about how far away the moon is…") and
+**emails it to you via Resend**. Text only — never audio.
+
+- The cron endpoint is protected by **`CRON_SECRET`** (Vercel sends it as a
+  Bearer token automatically; we fail closed if it's unset).
+- The send layer is **swappable**: `DIGEST_PROVIDER=sms` uses Twilio instead of
+  email — no change to the digest code.
+- Quiet days are skipped (no empty emails). You can also **"Email me today's
+  digest"** from the dashboard to test it immediately.
+
+**Setup:** add `CRON_SECRET` (`openssl rand -hex 32`), `RESEND_API_KEY` (from
+[resend.com](https://resend.com)), and `DIGEST_TO_EMAIL`. Optionally set
+`DIGEST_FROM_EMAIL` (defaults to Resend's shared sender until you verify a
+domain) and `DIGEST_CHILD_NAME` to personalize the note.
+
 ## Run it locally
 
 ```bash

--- a/questionbox/server/__tests__/digest.test.ts
+++ b/questionbox/server/__tests__/digest.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildDigest } from "@/lib/digest";
+import { isDigestConfigured, sendMessage } from "@/lib/email";
+import type { Interaction } from "@/lib/dashboard-data";
+
+function mk(partial: Partial<Interaction>): Interaction {
+  return {
+    id: Math.random().toString(36),
+    created_at: "2026-07-27T14:00:00.000Z",
+    question: null,
+    answer: null,
+    mode: "answered",
+    category: null,
+    reason: null,
+    is_spelling: false,
+    spell_word: null,
+    latency_ms: null,
+    ...partial,
+  };
+}
+
+describe("buildDigest", () => {
+  it("summarizes a day with example questions", () => {
+    const rows = [
+      mk({ question: "How far away is the moon?", mode: "answered" }),
+      mk({ question: "Why do volcanoes erupt?", mode: "answered" }),
+      mk({ question: "Where do babies come from?", mode: "deferred" }),
+    ];
+    const d = buildDigest("2026-07-27", rows, "Gus");
+    expect(d.total).toBe(3);
+    expect(d.subject).toContain("Gus");
+    expect(d.text).toContain("How far away is the moon?");
+    expect(d.text).toContain("Why do volcanoes erupt?");
+    // Deferred/answered counts appear.
+    expect(d.text).toMatch(/answered 2/);
+    expect(d.html).toContain("WonderBox");
+  });
+
+  it("dedupes repeated questions", () => {
+    const rows = [
+      mk({ question: "what is a triangle", mode: "answered" }),
+      mk({ question: "What is a triangle", mode: "answered" }),
+    ];
+    const d = buildDigest("2026-07-27", rows);
+    const occurrences = d.text.split("triangle").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("handles a quiet day", () => {
+    const d = buildDigest("2026-07-27", []);
+    expect(d.total).toBe(0);
+    expect(d.subject.toLowerCase()).toContain("quiet");
+  });
+});
+
+describe("send layer", () => {
+  beforeEach(() => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.DIGEST_TO_EMAIL;
+    delete process.env.DIGEST_PROVIDER;
+  });
+
+  it("is not configured and skips (never throws) without keys", async () => {
+    expect(isDigestConfigured()).toBe(false);
+    const r = await sendMessage({ subject: "hi", text: "hi", html: "<p>hi</p>" });
+    expect(r.sent).toBe(false);
+    expect(r.skipped).toBe("not_configured");
+  });
+});

--- a/questionbox/server/app/api/cron/digest/route.ts
+++ b/questionbox/server/app/api/cron/digest/route.ts
@@ -1,0 +1,28 @@
+import { runDigest, yesterdayStr } from "@/lib/run-digest";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/cron/digest — run daily by Vercel Cron.
+ *
+ * Vercel automatically sends `Authorization: Bearer <CRON_SECRET>` when the
+ * CRON_SECRET env var is set; we require it (fail closed) so nobody else can
+ * trigger digests. Summarizes the previous day by default; pass ?date=YYYY-MM-DD
+ * to target a specific day.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return Response.json({ error: "cron_secret_not_set" }, { status: 500 });
+
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) return Response.json({ error: "unauthorized" }, { status: 401 });
+
+  const url = new URL(request.url);
+  const dateParam = url.searchParams.get("date");
+  const date = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : yesterdayStr();
+
+  const result = await runDigest(date);
+  console.log(`[cron] digest ${date}: total=${result.total} sent=${result.send.sent} ${result.send.skipped ?? result.send.error ?? ""}`);
+  return Response.json({ ok: true, ...result });
+}

--- a/questionbox/server/app/dashboard/actions.ts
+++ b/questionbox/server/app/dashboard/actions.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { requireSession } from "@/lib/auth/guard";
+import { runDigest } from "@/lib/run-digest";
+import { todayStr } from "@/lib/dashboard-data";
+import { isDigestConfigured } from "@/lib/email";
+
+/** Manually build & send today's digest so you can test it without waiting for cron. */
+export async function sendDigestNowAction(): Promise<void> {
+  await requireSession();
+  if (!isDigestConfigured()) redirect("/dashboard?digest=unconfigured");
+
+  const result = await runDigest(todayStr(), /* force */ true);
+  redirect(`/dashboard?digest=${result.send.sent ? "sent" : "error"}`);
+}

--- a/questionbox/server/app/dashboard/page.tsx
+++ b/questionbox/server/app/dashboard/page.tsx
@@ -1,17 +1,34 @@
 import Link from "next/link";
 import { getDailySummary, todayStr } from "@/lib/dashboard-data";
 import { isSupabaseConfigured } from "@/lib/supabase";
+import { isDigestConfigured } from "@/lib/email";
+import { sendDigestNowAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
-export default async function DashboardHome() {
+const DIGEST_NOTE: Record<string, string> = {
+  sent: "Digest sent! Check your inbox.",
+  error: "Couldn't send the digest — check your email settings.",
+  unconfigured: "Set RESEND_API_KEY and DIGEST_TO_EMAIL to enable the digest.",
+};
+
+export default async function DashboardHome({
+  searchParams,
+}: {
+  searchParams: Promise<{ digest?: string }>;
+}) {
   const configured = isSupabaseConfigured();
   const today = todayStr();
   const summary = configured ? await getDailySummary(today) : null;
+  const { digest } = await searchParams;
 
   return (
     <section>
       <h1>Today</h1>
+
+      {digest && DIGEST_NOTE[digest] && (
+        <p className={digest === "sent" ? "note-ok" : "alert"}>{DIGEST_NOTE[digest]}</p>
+      )}
 
       {!configured && (
         <p className="alert">
@@ -52,10 +69,15 @@ export default async function DashboardHome() {
             </div>
           )}
 
-          <p>
+          <p className="row">
             <Link className="btn" href={`/dashboard/log?date=${today}`}>
               See today&apos;s questions
             </Link>
+            {isDigestConfigured() && (
+              <form action={sendDigestNowAction}>
+                <button className="btn-ghost" type="submit">Email me today&apos;s digest</button>
+              </form>
+            )}
           </p>
         </>
       )}

--- a/questionbox/server/app/globals.css
+++ b/questionbox/server/app/globals.css
@@ -399,3 +399,17 @@ code {
   color: var(--accent);
   font-weight: 600;
 }
+.note-ok {
+  background: #e9f8ef;
+  border: 1px solid #b9e6cb;
+  color: #1f7a45;
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+}
+.row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}

--- a/questionbox/server/lib/digest.ts
+++ b/questionbox/server/lib/digest.ts
@@ -1,0 +1,109 @@
+/**
+ * Builds the friendly daily digest from a day's interactions. Pure and
+ * testable — no network. The cron route loads the data and hands it here.
+ */
+import type { Interaction } from "./dashboard-data";
+
+export interface Digest {
+  subject: string;
+  text: string;
+  html: string;
+  total: number;
+}
+
+function prettyDate(date: string): string {
+  const d = new Date(`${date}T12:00:00.000Z`);
+  return d.toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", timeZone: "UTC" });
+}
+
+function cleanQuestion(q: string): string {
+  let s = q.trim().replace(/\s+/g, " ");
+  if (s.length > 90) s = s.slice(0, 87) + "…";
+  return s;
+}
+
+/** Dedupe (case-insensitive) and cap a list of questions. */
+function sampleQuestions(rows: Interaction[], max: number): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rows) {
+    const q = (r.question ?? "").trim();
+    if (!q) continue;
+    const key = q.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(cleanQuestion(q));
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+export function buildDigest(date: string, rows: Interaction[], childName?: string): Digest {
+  const who = childName && childName.trim() ? childName.trim() : "the kids";
+  const answered = rows.filter((r) => r.mode === "answered");
+  const deferred = rows.filter((r) => r.mode === "deferred");
+  const refused = rows.filter((r) => r.mode === "refused");
+  const total = rows.length;
+
+  const examples = sampleQuestions(answered.length ? answered : rows, 5);
+  const pretty = prettyDate(date);
+
+  const subject =
+    total === 0
+      ? `WonderBox — a quiet day (${date})`
+      : `WonderBox — ${who} asked ${total} question${total === 1 ? "" : "s"} (${date})`;
+
+  // Plain text
+  const lines: string[] = [];
+  if (total === 0) {
+    lines.push(`No questions for WonderBox on ${pretty}. A quiet day!`);
+  } else {
+    const intro =
+      examples.length > 0
+        ? `On ${pretty}, ${who} asked WonderBox about things like:`
+        : `On ${pretty}, ${who} asked WonderBox ${total} question${total === 1 ? "" : "s"}.`;
+    lines.push(intro, "");
+    for (const q of examples) lines.push(`  • ${q}`);
+    lines.push("");
+    lines.push(
+      `WonderBox answered ${answered.length}, gently sent ${deferred.length} to a grown-up` +
+        (refused.length ? `, and declined ${refused.length}` : "") + ".",
+    );
+    lines.push("");
+    lines.push("See everything in your dashboard.");
+  }
+  const text = lines.join("\n");
+
+  // HTML
+  const exHtml = examples.map((q) => `<li style="margin:4px 0;">${escapeHtml(q)}</li>`).join("");
+  const html = `
+  <div style="font-family:ui-rounded,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#3a3f58;max-width:520px;margin:0 auto;">
+    <div style="background:#fff3e0;border-radius:20px;padding:24px;">
+      <h1 style="font-size:22px;margin:0 0 6px;">WonderBox daily note</h1>
+      <p style="color:#8a8fa3;margin:0 0 16px;">${escapeHtml(pretty)}</p>
+      ${
+        total === 0
+          ? `<p>No questions today — a quiet day! 🌙</p>`
+          : `<p>${escapeHtml(who === "the kids" ? "The kids" : who)} asked WonderBox about:</p>
+             <ul style="padding-left:18px;">${exHtml}</ul>
+             <p style="margin-top:16px;">
+               <b style="color:#2e9e5b;">${answered.length}</b> answered,
+               <b style="color:#d98324;">${deferred.length}</b> sent to a grown-up${
+                 refused.length ? `, <b style="color:#c0392b;">${refused.length}</b> declined` : ""
+               }.
+             </p>`
+      }
+    </div>
+    <p style="font-size:12px;color:#8a8fa3;text-align:center;margin-top:14px;">Sent by your WonderBox • question &amp; answer text only, never audio</p>
+  </div>`;
+
+  return { subject, text, html, total };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/questionbox/server/lib/email.ts
+++ b/questionbox/server/lib/email.ts
@@ -1,0 +1,74 @@
+/**
+ * Swappable "send a message to the parent" layer.
+ *
+ * Default provider is email via Resend. Switch to SMS later by setting
+ * DIGEST_PROVIDER=sms (Twilio) — no change to the digest code. Sending never
+ * throws; it returns a small result so the caller can log/skip cleanly.
+ */
+
+export type SendResult = { sent: boolean; skipped?: string; error?: string };
+
+export interface OutgoingMessage {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+function provider(): "email" | "sms" {
+  return (process.env.DIGEST_PROVIDER || "email").toLowerCase() === "sms" ? "sms" : "email";
+}
+
+export function isDigestConfigured(): boolean {
+  if (provider() === "sms") {
+    return !!(
+      process.env.TWILIO_ACCOUNT_SID &&
+      process.env.TWILIO_AUTH_TOKEN &&
+      process.env.TWILIO_FROM &&
+      process.env.DIGEST_TO_SMS
+    );
+  }
+  return !!(process.env.RESEND_API_KEY && process.env.DIGEST_TO_EMAIL);
+}
+
+export async function sendMessage(msg: OutgoingMessage): Promise<SendResult> {
+  if (!isDigestConfigured()) return { sent: false, skipped: "not_configured" };
+  try {
+    return provider() === "sms" ? await sendViaTwilio(msg) : await sendViaResend(msg);
+  } catch (e) {
+    console.error("[digest] send failed:", e);
+    return { sent: false, error: (e as Error).message };
+  }
+}
+
+async function sendViaResend(msg: OutgoingMessage): Promise<SendResult> {
+  const apiKey = process.env.RESEND_API_KEY!;
+  const to = process.env.DIGEST_TO_EMAIL!;
+  const from = process.env.DIGEST_FROM_EMAIL || "WonderBox <onboarding@resend.dev>";
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ from, to, subject: msg.subject, html: msg.html, text: msg.text }),
+  });
+  if (!res.ok) return { sent: false, error: `resend_${res.status}: ${await res.text()}` };
+  return { sent: true };
+}
+
+async function sendViaTwilio(msg: OutgoingMessage): Promise<SendResult> {
+  const sid = process.env.TWILIO_ACCOUNT_SID!;
+  const token = process.env.TWILIO_AUTH_TOKEN!;
+  const from = process.env.TWILIO_FROM!;
+  const to = process.env.DIGEST_TO_SMS!;
+
+  const body = new URLSearchParams({ From: from, To: to, Body: `${msg.subject}\n\n${msg.text}`.slice(0, 1500) });
+  const res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`, {
+    method: "POST",
+    headers: {
+      Authorization: "Basic " + Buffer.from(`${sid}:${token}`).toString("base64"),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  if (!res.ok) return { sent: false, error: `twilio_${res.status}: ${await res.text()}` };
+  return { sent: true };
+}

--- a/questionbox/server/lib/run-digest.ts
+++ b/questionbox/server/lib/run-digest.ts
@@ -1,0 +1,30 @@
+import { getInteractionsByDay } from "./dashboard-data";
+import { buildDigest } from "./digest";
+import { sendMessage, type SendResult } from "./email";
+
+/** Yesterday's date (UTC) as YYYY-MM-DD — the day a morning digest summarizes. */
+export function yesterdayStr(now = new Date()): string {
+  const d = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+export interface RunDigestResult {
+  date: string;
+  total: number;
+  send: SendResult;
+}
+
+/**
+ * Builds and sends the digest for `date`. When there are no questions and
+ * `force` is false, it skips sending (no empty emails).
+ */
+export async function runDigest(date: string, force = false): Promise<RunDigestResult> {
+  const rows = await getInteractionsByDay(date);
+  const digest = buildDigest(date, rows, process.env.DIGEST_CHILD_NAME);
+
+  if (digest.total === 0 && !force) {
+    return { date, total: 0, send: { sent: false, skipped: "no_questions" } };
+  }
+  const send = await sendMessage({ subject: digest.subject, text: digest.text, html: digest.html });
+  return { date, total: digest.total, send };
+}

--- a/questionbox/server/vercel.json
+++ b/questionbox/server/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/digest",
+      "schedule": "0 13 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## WonderBox — Stage 7 (daily digest)

The final build stage: a once-a-day friendly summary emailed to the parent.

> Stacked on the Stage 6 branch so this PR's diff is only the Stage 7 changes.

### What it does
- **Vercel Cron** (`vercel.json` → `/api/cron/digest`, default 13:00 UTC) once a day summarizes the previous day's questions into a short, warm note — e.g. *"On Sunday, the kids asked WonderBox about how far away the moon is…"* — and **emails it via Resend**. **Text only, never audio.**
- Quiet days are skipped (no empty emails).
- **"Email me today's digest"** button on the dashboard to test it instantly.

### Security
- The cron endpoint requires **`CRON_SECRET`** (Vercel sends it as a Bearer token automatically) and **fails closed** if unset — nobody else can trigger digests.

### Swappable send layer (as requested)
- `lib/email.ts` sends via **Resend (email, default)** or **Twilio (SMS)** with `DIGEST_PROVIDER=sms` — no change to the digest code. Sending never throws; it skips cleanly when unconfigured.

### Code
- `lib/digest.ts` — pure, testable friendly-note builder (text + HTML), dedupes and samples example questions, handles quiet days.
- `lib/run-digest.ts` — orchestrator shared by the cron route and the dashboard button.

### Verification
- Tests: digest builder (examples / dedupe / quiet day) + send-layer no-op when unconfigured. **90 tests pass**; `typecheck` and `next build` green (new route `/api/cron/digest`).
- Docs pulled via **Context7** (Resend API).

### What you need to set (on Vercel)
`CRON_SECRET` (`openssl rand -hex 32`), `RESEND_API_KEY`, `DIGEST_TO_EMAIL`. Optional: `DIGEST_FROM_EMAIL` (defaults to Resend's shared sender until you verify a domain) and `DIGEST_CHILD_NAME` to personalize.

_Final stage of the staged build. Draft for review._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

