### PR TITLE
Fix microphone (shared I2S bus) + Apple/Siri-style face overhaul

### DIFF
--- a/questionbox/firmware/README.md
+++ b/questionbox/firmware/README.md
@@ -25,8 +25,10 @@ mic never listens on its own. **Audio is recorded, sent, and discarded — never
 stored** on the device.
 
 **How you interact:**
-- **Tap the face** to start listening (it grins big and shows ripples). Tap
-  again — or just stop talking — to send. There's no separate button.
+- **Tap the face** to start listening (it grins big and a soft, flowing light
+  sweeps around the edge, Siri-style). Tap again — or just stop talking — to
+  send. There's no separate button. The face also gently looks around and blinks
+  so it feels alive.
 - **Auto-sleep:** after 30 seconds of no use, the screen goes dark. **Tap to
   wake** it (that first tap only wakes; tap again to ask).
 - **Volume:** the two **physical buttons on the side** control the speaker

--- a/questionbox/firmware/src/audio/audio_bus.cpp
+++ b/questionbox/firmware/src/audio/audio_bus.cpp
@@ -1,0 +1,45 @@
+#include "audio_bus.h"
+#include <Arduino.h>
+
+// Mic (I2S MEMS)
+#define MIC_BCK 15
+#define MIC_WS  2
+#define MIC_DIN 39
+// Speaker (PCM5101 DAC)
+#define SPK_BCK 48
+#define SPK_WS  38
+#define SPK_DOUT 47
+
+I2SClass wb_i2s;
+static bool s_active = false;
+
+bool AudioBus_BeginMic()
+{
+  if (s_active) AudioBus_End();
+  wb_i2s.setPins(MIC_BCK, MIC_WS, -1 /*dout*/, MIC_DIN, -1 /*mclk*/);
+  if (!wb_i2s.begin(I2S_MODE_STD, 16000, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO)) {
+    Serial.println("[audio] mic begin FAILED");
+    return false;
+  }
+  s_active = true;
+  return true;
+}
+
+bool AudioBus_BeginSpeaker()
+{
+  if (s_active) AudioBus_End();
+  wb_i2s.setPins(SPK_BCK, SPK_WS, SPK_DOUT, -1 /*din*/, -1 /*mclk*/);
+  if (!wb_i2s.begin(I2S_MODE_STD, 24000, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO)) {
+    Serial.println("[audio] speaker begin FAILED");
+    return false;
+  }
+  s_active = true;
+  return true;
+}
+
+void AudioBus_End()
+{
+  if (!s_active) return;
+  wb_i2s.end();
+  s_active = false;
+}

--- a/questionbox/firmware/src/audio/audio_bus.h
+++ b/questionbox/firmware/src/audio/audio_bus.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <ESP_I2S.h>
+
+// A SINGLE shared I2S peripheral for both the microphone (record) and the
+// PCM5101 speaker (playback). They use different pins, so we (re)configure and
+// enable the one bus only for the operation we're doing right now, and disable
+// it afterwards. This avoids two drivers fighting over the hardware (which was
+// leaving the mic channel disabled -> 0 samples recorded).
+//
+// WonderBox is push-to-talk / half-duplex, so we never record and play at once.
+
+extern I2SClass wb_i2s;
+
+// Mic pins (Waveshare wiki): BCK 15, WS 2, DIN 39.
+bool AudioBus_BeginMic();      // enable RX @ 16 kHz stereo
+
+// Speaker pins (Waveshare wiki): BCK 48, WS 38, DOUT 47.
+bool AudioBus_BeginSpeaker();  // enable TX @ 24 kHz stereo
+
+void AudioBus_End();           // disable/free the bus

--- a/questionbox/firmware/src/audio/mic.cpp
+++ b/questionbox/firmware/src/audio/mic.cpp
@@ -1,26 +1,20 @@
 #include "mic.h"
+#include "audio_bus.h"
 #include <Arduino.h>
-#include <ESP_I2S.h>
 #include <esp_heap_caps.h>
+#include <math.h>
 
-// ---- Microphone I2S pins (Waveshare wiki) ----
-#define MIC_BCK   15
-#define MIC_WS     2
-#define MIC_DIN   39
-
-#define REC_RATE        16000        // 16 kHz is plenty for speech-to-text
+#define REC_RATE        16000
 #define REC_MAX_SEC     10
-#define REC_MAX_SAMPLES (REC_RATE * REC_MAX_SEC)   // mono samples
+#define REC_MAX_SAMPLES (REC_RATE * REC_MAX_SEC)
 #define WAV_HEADER_LEN  44
 
-// Auto-stop tuning.
-#define SILENCE_RMS      700         // below this counts as "quiet"
-#define SILENCE_MS       1200        // stop this long after speech ends
-#define MIN_RECORD_MS    400         // don't auto-stop before this
+#define SILENCE_RMS      700
+#define SILENCE_MS       1200
+#define MIN_RECORD_MS    400
 
-static I2SClass s_i2s;
 static uint8_t *s_buf = nullptr;     // [WAV header | mono int16 PCM]
-static size_t   s_count = 0;         // mono samples captured
+static size_t   s_count = 0;
 static bool     s_recording = false;
 
 static bool     s_speech = false;
@@ -44,7 +38,7 @@ static void write_wav_header(uint8_t *h, uint32_t dataLen, uint32_t rate)
   memcpy(h + 8, "WAVE", 4);
   memcpy(h + 12, "fmt ", 4);
   *(uint32_t *)(h + 16) = 16;
-  *(uint16_t *)(h + 20) = 1;          // PCM
+  *(uint16_t *)(h + 20) = 1;
   *(uint16_t *)(h + 22) = channels;
   *(uint32_t *)(h + 24) = rate;
   *(uint32_t *)(h + 28) = byteRate;
@@ -56,30 +50,23 @@ static void write_wav_header(uint8_t *h, uint32_t dataLen, uint32_t rate)
 
 bool Mic_Begin()
 {
+  // Only allocate the record buffer here. The I2S bus is enabled on demand in
+  // Mic_Start() (shared with the speaker), so nothing fights over the hardware.
   s_buf = (uint8_t *)heap_caps_malloc(WAV_HEADER_LEN + REC_MAX_SAMPLES * 2, MALLOC_CAP_SPIRAM);
   if (!s_buf) {
     Serial.println("[mic] FAILED to allocate PSRAM record buffer");
     return false;
   }
-  // Capture in STEREO and sum the two slots when downmixing: this makes us
-  // robust to whether the MEMS mic sits on the left or right I2S slot.
-  s_i2s.setPins(MIC_BCK, MIC_WS, -1 /*dout*/, MIC_DIN, -1 /*mclk*/);
-  if (!s_i2s.begin(I2S_MODE_STD, REC_RATE, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO)) {
-    Serial.println("[mic] i2s begin FAILED");
-    return false;
-  }
-  Serial.println("[mic] ready");
+  Serial.println("[mic] buffer ready");
   return true;
 }
 
 void Mic_Start()
 {
-  // Drop any stale samples sitting in the DMA buffer.
-  uint8_t scratch[512];
-  while (s_i2s.available() > 0) {
-    int n = s_i2s.available();
-    if (n > (int)sizeof(scratch)) n = sizeof(scratch);
-    if (s_i2s.readBytes((char *)scratch, n) <= 0) break;
+  if (!AudioBus_BeginMic()) {
+    Serial.println("[mic] could not enable mic bus");
+    s_recording = false;
+    return;
   }
   s_count = 0;
   s_recording = true;
@@ -93,6 +80,7 @@ void Mic_Stop()
 {
   if (!s_recording) return;
   s_recording = false;
+  AudioBus_End();
   Serial.printf("[mic] recording stopped (%u samples, %.2fs)\n",
                 (unsigned)s_count, (float)s_count / REC_RATE);
 }
@@ -101,21 +89,20 @@ bool Mic_Poll()
 {
   if (!s_recording) return false;
 
-  // Read whatever is currently available (non-blocking), a chunk at a time.
-  uint8_t tmp[2048];                          // stereo int16 frames = 4 bytes each
-  int avail = s_i2s.available();
+  uint8_t tmp[2048];
+  int avail = wb_i2s.available();
   if (avail > 0) {
     int n = avail;
     if (n > (int)sizeof(tmp)) n = sizeof(tmp);
-    n &= ~0x3;                                 // whole stereo frames only
+    n &= ~0x3;
     if (n > 0) {
-      int got = s_i2s.readBytes((char *)tmp, n);
+      int got = wb_i2s.readBytes((char *)tmp, n);
       int frames = got / 4;
       int16_t *in = (int16_t *)tmp;
       int16_t *out = (int16_t *)(s_buf + WAV_HEADER_LEN);
       uint64_t energy = 0;
       for (int i = 0; i < frames && s_count < REC_MAX_SAMPLES; i++) {
-        int32_t mono = (int32_t)in[i * 2] + (int32_t)in[i * 2 + 1];  // L + R
+        int32_t mono = (int32_t)in[i * 2] + (int32_t)in[i * 2 + 1];
         int16_t m = clamp16(mono);
         out[s_count++] = m;
         energy += (uint64_t)((int32_t)m * m);

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -1,14 +1,5 @@
 #include "speaker.h"
-#include <ESP_I2S.h>
-
-// ---- Speaker (PCM5101 DAC) I2S pins (Waveshare wiki) ----
-#define SPK_BCK   48
-#define SPK_WS    38
-#define SPK_DOUT  47
-
-#define PLAY_RATE 24000    // answer audio is 24 kHz mono (see server lib/wav.ts)
-
-static I2SClass s_i2s;
+#include "audio_bus.h"
 
 // Software gain applied before the samples reach the DAC. 1.0 = original level.
 // A gentle boost helps if the answer sounds quiet even with the amp turned up.
@@ -33,12 +24,8 @@ static inline int16_t apply_gain(int16_t sample)
 
 bool Speaker_Begin()
 {
-  s_i2s.setPins(SPK_BCK, SPK_WS, SPK_DOUT, -1 /*din*/, -1 /*mclk*/);
-  if (!s_i2s.begin(I2S_MODE_STD, PLAY_RATE, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO)) {
-    Serial.println("[spk] i2s begin FAILED");
-    return false;
-  }
-  Serial.println("[spk] ready");
+  // The I2S bus is enabled on demand in Speaker_PlayWavStream() (shared with the
+  // mic). Nothing to do at boot.
   return true;
 }
 
@@ -73,6 +60,11 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
     return;
   }
 
+  if (!AudioBus_BeginSpeaker()) {
+    Serial.println("[spk] could not enable speaker bus");
+    return;
+  }
+
   int dataRemaining = (contentLen > 44) ? (contentLen - 44) : INT32_MAX;
 
   int16_t mono[512];
@@ -94,9 +86,10 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
       stereo[i * 2] = s;
       stereo[i * 2 + 1] = s;
     }
-    s_i2s.write((uint8_t *)stereo, samples * 2 * sizeof(int16_t));
+    wb_i2s.write((uint8_t *)stereo, samples * 2 * sizeof(int16_t));
 
     if (pump) pump();
   }
+  AudioBus_End();
   Serial.println("[spk] playback done");
 }

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -1,18 +1,19 @@
 /*****************************************************************************
- * The WonderBox face.
+ * The WonderBox face — clean, cute, and alive.
  *
- * A warm, friendly, smiling face for the 360x360 round LCD. Everything is drawn
- * with plain LVGL objects (no image assets). One look per state:
+ * Design goals (Apple-clean + cutesy):
+ *   - a happy face by default that gently blinks and LOOKS AROUND
+ *   - a smooth, flowing "Siri-style" glow around the round edge while it is
+ *     listening / thinking / speaking (rotating soft light, not choppy rings)
+ *   - clear per-state looks:
+ *       IDLE      calm smile, eyes wander, no edge glow
+ *       LISTENING big smile + bright fast flowing edge
+ *       THINKING  eyes glance up + slow, dim flowing edge
+ *       SPEAKING  talking mouth + medium flowing edge
+ *       SPELLING  one big letter at a time
  *
- *   IDLE      gentle blink, soft SMILE       -> ready and calm
- *   LISTENING big grin + expanding ripples   -> "I'm listening"
- *   THINKING  eyes glance up, bouncing dots  -> a charming wait
- *   SPEAKING  mouth opens and closes         -> talking
- *   SPELLING  one big letter at a time        -> spelling a word
- *
- * The smile is a crescent: a dark mouth shape with a background-colored shape
- * nudged over the top of it, leaving a smiling curve. Only the small, moving
- * parts animate each frame (eyes, ripples, talking mouth), so it stays fluid.
+ * Everything is drawn with LVGL vector primitives (arcs + rounded shapes), so
+ * it stays crisp and anti-aliased. Only moving parts update each frame.
  *****************************************************************************/
 #include "face.h"
 #include <Arduino.h>
@@ -24,33 +25,40 @@
 #define COL_BG      0xFFF3E0
 #define COL_INK     0x3A3F58
 #define COL_CHEEK   0xFFB4A2
-#define COL_ACCENT  0xFF7A59
-#define COL_DOT     0x6FA8FF
 #define COL_LETTER  0x2E7DE1
+// Flowing edge-glow colors (blend as they overlap)
+#define COL_GLOW1   0xFF7A59  // coral
+#define COL_GLOW2   0x6FA8FF  // blue
+#define COL_GLOW3   0xB18CFF  // lavender
 
-// ---- Base geometry (center 180,180) ----
-static const int EYE_D    = 66;
-static const int EYE_DX   = 62;
-static const int EYE_DY   = -34;
-static const int MOUTH_DY = 46;
+// ---- Geometry (center 180,180) ----
+static const int EYE_D    = 60;
+static const int EYE_DX   = 60;
+static const int EYE_DY   = -30;
+static const int MOUTH_DY = 34;
+static const int EDGE_D   = 352;
 
 // ---- Objects ----
 static lv_obj_t *eye_l, *eye_r;
 static lv_obj_t *cheek_l, *cheek_r;
-static lv_obj_t *mouth;       // dark mouth shape (smile base, and the talking mouth)
-static lv_obj_t *smile_mask;  // background-colored shape that carves the smile curve
-static lv_obj_t *ripples[3];  // expanding "listening" waves
-static lv_obj_t *dots[3];     // thinking
+static lv_obj_t *smile;        // arc smile (idle/listening/thinking)
+static lv_obj_t *talk;         // filled mouth (speaking)
+static lv_obj_t *comets[3];    // flowing edge glow
 static lv_obj_t *letter_lbl, *word_lbl;
 
 static WbState current = WB_IDLE;
-static uint32_t blink_next_ms = 0;
-static uint32_t blink_start_ms = 0;
+
+// blink
+static uint32_t blink_next_ms = 0, blink_start_ms = 0;
 static const uint32_t BLINK_MS = 150;
 
+// gaze (look-around)
+static float gaze_cx = 0, gaze_cy = 0, gaze_tx = 0, gaze_ty = 0;
+static uint32_t gaze_next_ms = 0;
+
+// spelling
 static char spell_word[32] = {0};
-static int  spell_len = 0;
-static int  spell_index = 0;
+static int spell_len = 0, spell_index = 0;
 static uint32_t spell_last_ms = 0;
 static const uint32_t SPELL_STEP_MS = 800;
 
@@ -66,26 +74,32 @@ static lv_obj_t *make_blob(lv_obj_t *parent, uint32_t color, lv_opa_t opa)
   return o;
 }
 
+static lv_obj_t *make_arc(lv_obj_t *parent, uint32_t color, int size, int width)
+{
+  lv_obj_t *a = lv_arc_create(parent);
+  lv_obj_remove_style_all(a);
+  lv_obj_clear_flag(a, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_clear_flag(a, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_set_size(a, size, size);
+  lv_obj_center(a);
+  lv_arc_set_rotation(a, 0);
+  lv_arc_set_bg_angles(a, 0, 10);
+  lv_obj_set_style_arc_color(a, lv_color_hex(color), LV_PART_MAIN);
+  lv_obj_set_style_arc_width(a, width, LV_PART_MAIN);
+  lv_obj_set_style_arc_rounded(a, true, LV_PART_MAIN);
+  lv_obj_set_style_arc_width(a, 0, LV_PART_INDICATOR);          // hide indicator
+  lv_obj_set_style_bg_opa(a, LV_OPA_TRANSP, LV_PART_KNOB);      // hide knob
+  lv_obj_set_style_pad_all(a, 0, LV_PART_KNOB);
+  return a;
+}
+
 static inline void show(lv_obj_t *o, bool v)
 {
   if (v) lv_obj_clear_flag(o, LV_OBJ_FLAG_HIDDEN);
   else   lv_obj_add_flag(o, LV_OBJ_FLAG_HIDDEN);
 }
 
-static void schedule_blink(uint32_t now)
-{
-  blink_next_ms = now + 2400 + (esp_random() % 2600);
-}
-
-// Configure the crescent smile. `grin` = how big/open the smile is (pixels the
-// mask is lifted above the mouth). Bigger grin = bigger smile.
-static void set_smile(int width, int grin)
-{
-  lv_obj_set_size(mouth, width, 66);
-  lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
-  lv_obj_set_size(smile_mask, width + 24, 66);
-  lv_obj_align(smile_mask, LV_ALIGN_CENTER, 0, MOUTH_DY - grin);
-}
+static void schedule_blink(uint32_t now) { blink_next_ms = now + 2400 + (esp_random() % 2600); }
 
 void Face_Create(void)
 {
@@ -94,41 +108,32 @@ void Face_Create(void)
   lv_obj_set_style_bg_color(scr, lv_color_hex(COL_BG), 0);
   lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
 
-  // Ripples first (behind everything).
+  // Edge glow (behind everything): three colored arc segments we rotate.
+  const uint32_t glow_cols[3] = {COL_GLOW1, COL_GLOW2, COL_GLOW3};
   for (int i = 0; i < 3; i++) {
-    ripples[i] = lv_obj_create(scr);
-    lv_obj_remove_style_all(ripples[i]);
-    lv_obj_clear_flag(ripples[i], LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_clear_flag(ripples[i], LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_style_radius(ripples[i], LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_opa(ripples[i], LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_color(ripples[i], lv_color_hex(COL_ACCENT), 0);
-    lv_obj_set_style_border_width(ripples[i], 6, 0);
-    lv_obj_set_style_border_opa(ripples[i], LV_OPA_TRANSP, 0);
+    comets[i] = make_arc(scr, glow_cols[i], EDGE_D, 16);
+    lv_arc_set_bg_angles(comets[i], 0, 96);   // fixed segment; we spin via rotation
   }
 
   cheek_l = make_blob(scr, COL_CHEEK, LV_OPA_50);
   cheek_r = make_blob(scr, COL_CHEEK, LV_OPA_50);
-  lv_obj_set_size(cheek_l, 34, 34);
-  lv_obj_set_size(cheek_r, 34, 34);
-  lv_obj_align(cheek_l, LV_ALIGN_CENTER, -96, 12);
-  lv_obj_align(cheek_r, LV_ALIGN_CENTER, 96, 12);
+  lv_obj_set_size(cheek_l, 30, 30);
+  lv_obj_set_size(cheek_r, 30, 30);
+  lv_obj_align(cheek_l, LV_ALIGN_CENTER, -92, 8);
+  lv_obj_align(cheek_r, LV_ALIGN_CENTER, 92, 8);
 
   eye_l = make_blob(scr, COL_INK, LV_OPA_COVER);
   eye_r = make_blob(scr, COL_INK, LV_OPA_COVER);
   lv_obj_set_size(eye_l, EYE_D, EYE_D);
   lv_obj_set_size(eye_r, EYE_D, EYE_D);
-  lv_obj_align(eye_l, LV_ALIGN_CENTER, -EYE_DX, EYE_DY);
-  lv_obj_align(eye_r, LV_ALIGN_CENTER, EYE_DX, EYE_DY);
 
-  mouth = make_blob(scr, COL_INK, LV_OPA_COVER);
-  smile_mask = make_blob(scr, COL_BG, LV_OPA_COVER); // same as background -> carves a smile
+  // Smile arc (bottom curve of a circle = a happy smile).
+  smile = make_arc(scr, COL_INK, 96, 12);
 
-  for (int i = 0; i < 3; i++) {
-    dots[i] = make_blob(scr, COL_DOT, LV_OPA_COVER);
-    lv_obj_set_size(dots[i], 22, 22);
-    lv_obj_align(dots[i], LV_ALIGN_CENTER, (i - 1) * 34, 40);
-  }
+  // Talking mouth (open/close during speech).
+  talk = make_blob(scr, COL_INK, LV_OPA_COVER);
+  lv_obj_set_size(talk, 78, 26);
+  lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY);
 
   letter_lbl = lv_label_create(scr);
   lv_obj_set_style_text_color(letter_lbl, lv_color_hex(COL_LETTER), 0);
@@ -148,41 +153,46 @@ void Face_Create(void)
 
 WbState Face_GetState(void) { return current; }
 
+// Position the smile arc. `wide` = broader, happier smile.
+static void set_smile(bool wide)
+{
+  int a = wide ? 28 : 34;          // start angle
+  int b = wide ? 152 : 146;        // end angle (through 90 = bottom = smile)
+  lv_arc_set_bg_angles(smile, a, b);
+  int size = wide ? 108 : 96;
+  lv_obj_set_size(smile, size, size);
+  lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - size / 2 + 8);
+}
+
 void Face_SetState(WbState state)
 {
   current = state;
   Serial.printf("[face] state -> %s\n", wb_state_name(state));
 
-  const bool is_face  = (state != WB_SPELLING);
-  const bool is_think = (state == WB_THINKING);
-  const bool is_spk   = (state == WB_SPEAKING);
-  const bool is_listen = (state == WB_LISTENING);
-  const bool is_spell = (state == WB_SPELLING);
+  const bool face   = (state != WB_SPELLING);
+  const bool listen = (state == WB_LISTENING);
+  const bool think  = (state == WB_THINKING);
+  const bool speak  = (state == WB_SPEAKING);
+  const bool spell  = (state == WB_SPELLING);
+  const bool glow   = (listen || think || speak);
 
-  show(eye_l, is_face);
-  show(eye_r, is_face);
-  show(cheek_l, is_face);
-  show(cheek_r, is_face);
-  // Mouth shows for idle/listening (as a smile) and speaking (as an open mouth).
-  show(mouth, is_face && !is_think);
-  // The mask is only shown to carve the smile (idle/listening), not while talking.
-  show(smile_mask, (state == WB_IDLE || is_listen));
-  for (int i = 0; i < 3; i++) show(dots[i], is_think);
-  for (int i = 0; i < 3; i++) show(ripples[i], is_listen);
-  show(letter_lbl, is_spell);
-  show(word_lbl, is_spell);
+  show(eye_l, face);
+  show(eye_r, face);
+  show(cheek_l, face);
+  show(cheek_r, face);
+  show(smile, face && !speak);        // smile for idle/listening/thinking
+  show(talk, speak);                  // open mouth only while speaking
+  for (int i = 0; i < 3; i++) show(comets[i], glow);
+  show(letter_lbl, spell);
+  show(word_lbl, spell);
 
-  // Static smile geometry (set once per state so it isn't redrawn every frame).
-  if (state == WB_IDLE) set_smile(110, 30);       // soft, friendly smile
-  else if (is_listen)   set_smile(124, 46);       // big, happy grin
-  else if (is_spk) {                              // speaking: reset mouth position
-    lv_obj_set_size(mouth, 84, 26);
-    lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
-  }
+  if (face && !speak) set_smile(listen);   // big happy smile while listening
 
   uint32_t now = lv_tick_get();
   blink_start_ms = 0;
   schedule_blink(now);
+  gaze_next_ms = now + 400;
+  gaze_tx = gaze_ty = 0;
   spell_last_ms = now;
 }
 
@@ -203,35 +213,53 @@ void Face_ShowSpelling(const char *word)
   spell_last_ms = lv_tick_get();
 }
 
-static void set_eye_open(float open)
-{
-  int h = (int)(6 + (EYE_D - 6) * open);
-  if (h < 6) h = 6;
-  lv_obj_set_height(eye_l, h);
-  lv_obj_set_height(eye_r, h);
-}
-
-static void set_eye_look(int dy)
-{
-  lv_obj_align(eye_l, LV_ALIGN_CENTER, -EYE_DX, EYE_DY + dy);
-  lv_obj_align(eye_r, LV_ALIGN_CENTER, EYE_DX, EYE_DY + dy);
-}
-
 static float blink_factor(uint32_t now)
 {
   if (blink_start_ms == 0 && now >= blink_next_ms) blink_start_ms = now;
   if (blink_start_ms != 0) {
     uint32_t t = now - blink_start_ms;
-    if (t >= BLINK_MS) {
-      blink_start_ms = 0;
-      schedule_blink(now);
-      return 1.0f;
-    }
+    if (t >= BLINK_MS) { blink_start_ms = 0; schedule_blink(now); return 1.0f; }
     float p = (float)t / BLINK_MS;
-    float closed = 1.0f - fabsf(1.0f - 2.0f * p);
-    return 1.0f - closed;
+    return 1.0f - (1.0f - fabsf(1.0f - 2.0f * p));
   }
   return 1.0f;
+}
+
+// Smoothly wander the eyes to make the face feel alive.
+static void update_gaze(uint32_t now, bool wander)
+{
+  if (wander && now >= gaze_next_ms) {
+    if (esp_random() % 3 == 0) { gaze_tx = 0; gaze_ty = 0; }      // often re-center
+    else {
+      gaze_tx = ((int)(esp_random() % 29) - 14);                  // -14..14
+      gaze_ty = ((int)(esp_random() % 15) - 7);                   // -7..7
+    }
+    gaze_next_ms = now + 900 + (esp_random() % 1500);
+  }
+  gaze_cx += (gaze_tx - gaze_cx) * 0.12f;                          // ease toward target
+  gaze_cy += (gaze_ty - gaze_cy) * 0.12f;
+}
+
+static void place_eyes(float open)
+{
+  int h = (int)(6 + (EYE_D - 6) * open);
+  if (h < 6) h = 6;
+  int dx = (int)gaze_cx, dy = (int)gaze_cy;
+  lv_obj_set_height(eye_l, h);
+  lv_obj_set_height(eye_r, h);
+  lv_obj_align(eye_l, LV_ALIGN_CENTER, -EYE_DX + dx, EYE_DY + dy);
+  lv_obj_align(eye_r, LV_ALIGN_CENTER, EYE_DX + dx, EYE_DY + dy);
+}
+
+// Rotate the three glow arcs to make a smooth flowing edge of light.
+static void spin_edge(float base_deg, lv_opa_t opa)
+{
+  for (int i = 0; i < 3; i++) {
+    int rot = ((int)base_deg + i * 120) % 360;
+    if (rot < 0) rot += 360;
+    lv_arc_set_rotation(comets[i], rot);
+    lv_obj_set_style_arc_opa(comets[i], opa, LV_PART_MAIN);
+  }
 }
 
 void Face_Tick(void)
@@ -241,44 +269,32 @@ void Face_Tick(void)
 
   switch (current) {
     case WB_IDLE:
-      set_eye_look(0);
-      set_eye_open(blink_factor(now));
+      update_gaze(now, true);
+      place_eyes(blink_factor(now));
       break;
 
-    case WB_LISTENING: {
-      set_eye_look(0);
-      set_eye_open(blink_factor(now));
-      // Expanding ripples out to the edge = "I'm listening" waves.
-      for (int i = 0; i < 3; i++) {
-        float p = fmodf(t * 0.8f - i * 0.34f, 1.0f);
-        if (p < 0) p += 1.0f;
-        int d = 210 + (int)(180 * p);
-        lv_obj_set_size(ripples[i], d, d);
-        lv_obj_center(ripples[i]);
-        lv_obj_set_style_border_opa(ripples[i], (lv_opa_t)((1.0f - p) * 170), 0);
-      }
+    case WB_LISTENING:
+      update_gaze(now, true);
+      place_eyes(blink_factor(now));
+      spin_edge(t * 210.0f, 220);            // bright, fast, flowing
       break;
-    }
 
     case WB_THINKING:
-      set_eye_look(-10);
-      set_eye_open(blink_factor(now));
-      for (int i = 0; i < 3; i++) {
-        float ph = t * 4.0f - i * 0.6f;
-        float bob = sinf(ph);
-        int dy = 40 - (int)(10 * fmaxf(0.0f, bob));
-        lv_obj_align(dots[i], LV_ALIGN_CENTER, (i - 1) * 34, dy);
-        lv_obj_set_style_bg_opa(dots[i], (lv_opa_t)(120 + 120 * (0.5f + 0.5f * bob)), 0);
-      }
+      gaze_tx = 0; gaze_ty = -8;             // glance up, pondering
+      update_gaze(now, false);
+      place_eyes(blink_factor(now));
+      spin_edge(t * 75.0f, 110);             // slow, gentle
       break;
 
     case WB_SPEAKING: {
-      set_eye_look(0);
-      set_eye_open(blink_factor(now));
+      gaze_tx = 0; gaze_ty = 0;
+      update_gaze(now, false);
+      place_eyes(blink_factor(now));
       float m = 0.5f + 0.5f * sinf(t * 11.0f);
-      int h = 16 + (int)(42 * m);
-      lv_obj_set_size(mouth, 84, h);
-      lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
+      int h = 16 + (int)(40 * m);
+      lv_obj_set_size(talk, 80, h);
+      lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY);
+      spin_edge(t * 130.0f, 170);            // medium
       break;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The microphone bug (from the serial log)
The log showed `i2s_channel_read: The channel is not enabled` → `0 samples` recorded. Root cause: the mic and speaker were **two separate I2S drivers fighting over the same hardware**, so starting the speaker at boot left the mic's receive channel disabled — it captured nothing and never sent.

**Fix:** a single **shared I2S bus** (`audio_bus.*`) that's enabled for the **mic only while recording** and the **speaker only while playing** (WonderBox is push-to-talk, so it never needs both at once). This is the standard half-duplex pattern for this board.

## Apple/Siri-style UI overhaul
- **Happier, cleaner face**: proper arc **smile**, soft cheeks, cuter proportions.
- **Alive & expressive**: the eyes gently **look around** and blink on their own.
- **Flowing edge glow**: three soft colored arcs **rotate smoothly around the round edge** (Siri-style) — bright/fast while **listening**, slow/dim while **thinking**, medium while **speaking**. Replaces the choppy expanding circles.
- Clean/calm IDLE (no glow).

Builds clean (`pio run`: RAM 56%, flash 21.5%).

## Please test after flashing
Especially: tap the face, ask a question, and check the serial log now shows **`recording stopped (NNNN samples)`** with a non-zero count (that means the mic is finally capturing). Then whether the answer plays (press the **+ side button** for amp volume).

Merge to `main`, then re-download + re-flash.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

