### PR TITLE
Fix HTTPS connect: free internal RAM for TLS + connection timeouts

### DIFF
--- a/questionbox/firmware/src/board/LVGL_Driver.h
+++ b/questionbox/firmware/src/board/LVGL_Driver.h
@@ -9,9 +9,10 @@
 #define LCD_WIDTH     EXAMPLE_LCD_WIDTH
 #define LCD_HEIGHT    EXAMPLE_LCD_HEIGHT
 
-// Partial render buffer: 1/6 of the screen, double-buffered. Bigger buffer =
-// fewer flushes per frame = smoother animation, while still fitting SRAM.
-#define LVGL_BUF_LEN  (LCD_WIDTH * LCD_HEIGHT / 6)
+// Partial render buffer: 1/12 of the screen, double-buffered. Kept modest so
+// there's plenty of internal RAM left for the Wi-Fi/TLS network stack (a bigger
+// buffer starved the HTTPS handshake and broke the server call).
+#define LVGL_BUF_LEN  (LCD_WIDTH * LCD_HEIGHT / 12)
 
 #define EXAMPLE_LVGL_TICK_PERIOD_MS  10
 

--- a/questionbox/firmware/src/net/wonder_client.cpp
+++ b/questionbox/firmware/src/net/wonder_client.cpp
@@ -64,6 +64,10 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
 #else
   s_tls.setCACert(WB_ROOT_CA);
 #endif
+  s_tls.setHandshakeTimeout(20);   // seconds; give the TLS handshake room
+
+  Serial.printf("[net] free heap %u, largest block %u\n",
+                (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMaxAllocHeap());
 
   String url = String(SERVER_BASE_URL) + "/api/ask";
   if (!s_http.begin(s_tls, url)) {
@@ -72,7 +76,8 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
   }
   s_open = true;
 
-  s_http.setTimeout(15000);
+  s_http.setConnectTimeout(20000);
+  s_http.setTimeout(20000);
   s_http.addHeader("Content-Type", "audio/wav");
   s_http.addHeader("Authorization", String("Bearer ") + DEVICE_TOKEN);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The mic now records (your log: `recording stopped (45056 samples, 2.82s)` 🎉). The next failure was the server call:
```
start_ssl_client: connect failed: -1
setSocketOption(): errno: 9, "Bad file number"
[net] status -1
```
That's the TLS/HTTPS handshake failing for lack of **internal RAM** — the enlarged LVGL display buffer (from the UI polish) had eaten the memory the network stack needs.

## Fix
- LVGL draw buffer **1/6 → 1/12** of the screen → frees ~43KB internal RAM (static RAM 56% → 43%).
- Added **TLS handshake timeout (20s)** and HTTP connect/read timeouts.
- Logs **free heap + largest block** before each request so we can confirm memory is healthy.

Builds clean (RAM 43%, flash 21.3%).

After flashing, the log will print `[net] free heap ...` before the POST, and the goal is `[net] status 200` + `[spk] playback done`.

**Also recommended:** point the device's `SERVER_BASE_URL` at your **production** Vercel domain (the short one without the random deployment hash), and make sure **Deployment Protection** is off for it, so the request isn't blocked once the connection succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

