### PR TITLE
Robust STT (whisper-1) + boot test tone + Vercel 302 handling

### DIFF
--- a/questionbox/firmware/include/device_config.h
+++ b/questionbox/firmware/include/device_config.h
@@ -25,6 +25,11 @@
 #define DEVICE_TOKEN ""
 #endif
 
+// Optional: only needed if you keep Vercel Deployment Protection ON.
+#ifndef VERCEL_BYPASS_SECRET
+#define VERCEL_BYPASS_SECRET ""
+#endif
+
 // True only when the essential fields have been filled in.
 static inline bool DeviceConfigValid()
 {

--- a/questionbox/firmware/include/secrets.h.example
+++ b/questionbox/firmware/include/secrets.h.example
@@ -18,3 +18,8 @@
 // Shared secret so only your box can call the server. Generate a long random
 // value (e.g. `openssl rand -hex 32`) and set the SAME value in the server env.
 #define DEVICE_TOKEN    "replace-with-a-long-random-token"
+
+// OPTIONAL: only if you keep Vercel "Deployment Protection" turned ON. Create a
+// "Protection Bypass for Automation" secret in Vercel and paste it here. If you
+// turn protection OFF (recommended), leave this out.
+// #define VERCEL_BYPASS_SECRET "your-vercel-bypass-secret"

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -56,6 +56,28 @@ static int read_exact(Stream &s, uint8_t *buf, int want, void (*pump)())
   return got;
 }
 
+void Speaker_TestBeep()
+{
+  const int rate = 24000;
+  const int total = rate / 2;        // 0.5 seconds
+  int16_t buf[256 * 2];
+  int done = 0;
+  while (done < total) {
+    int cnt = (total - done) < 256 ? (total - done) : 256;
+    for (int i = 0; i < cnt; i++) {
+      float t = (float)(done + i) / rate;
+      float env = sinf(3.14159265f * (done + i) / total);   // gentle fade in/out
+      float s = sinf(2.0f * 3.14159265f * 700.0f * t) * 0.35f * env;
+      int16_t v = (int16_t)(s * 32767);
+      buf[i * 2] = v;
+      buf[i * 2 + 1] = v;
+    }
+    AudioBus_SpeakerWrite(buf, cnt * 2 * sizeof(int16_t));   // raw, ignores volume
+    done += cnt;
+  }
+  Serial.println("[spk] test beep played");
+}
+
 void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
 {
   uint8_t header[44];

--- a/questionbox/firmware/src/audio/speaker.h
+++ b/questionbox/firmware/src/audio/speaker.h
@@ -20,3 +20,7 @@ float Speaker_GetGain();
 
 // Volume as a friendly 0..100 percent (mapped to a safe gain range).
 void Speaker_SetVolumePercent(int pct);
+
+// Plays a short tone at boot to verify the speaker/amplifier path works
+// (independent of the network). If you hear it, the speaker is wired and on.
+void Speaker_TestBeep();

--- a/questionbox/firmware/src/main.cpp
+++ b/questionbox/firmware/src/main.cpp
@@ -197,6 +197,7 @@ void setup()
   Mic_Begin();
   Speaker_Begin();
   Speaker_SetVolumePercent(g_volume);
+  Speaker_TestBeep();   // if you hear a short beep, the speaker path works
 
   WiFiConn_Connect();
 

--- a/questionbox/firmware/src/net/wonder_client.cpp
+++ b/questionbox/firmware/src/net/wonder_client.cpp
@@ -81,12 +81,24 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
   s_http.addHeader("Content-Type", "audio/wav");
   s_http.addHeader("Authorization", String("Bearer ") + DEVICE_TOKEN);
 
+  // Optional: bypass Vercel Deployment Protection without disabling it.
+  if (sizeof(VERCEL_BYPASS_SECRET) > 1) {
+    s_http.addHeader("x-vercel-protection-bypass", VERCEL_BYPASS_SECRET);
+    s_http.addHeader("x-vercel-set-bypass-cookie", "true");
+  }
+
   static const char *collect[] = {"X-Answer-Text", "X-Answer-Mode", "X-Is-Spelling", "X-Spell-Word"};
   s_http.collectHeaders(collect, 4);
 
   Serial.printf("[net] POST %s (%u bytes)\n", url.c_str(), (unsigned)len);
   int code = s_http.POST((uint8_t *)wav, len);
   Serial.printf("[net] status %d\n", code);
+
+  if (code >= 300 && code < 400) {
+    Serial.println("[net] server redirected (3xx). This is almost always Vercel");
+    Serial.println("[net] Deployment Protection. Fix: turn it OFF (or 'Only Preview')");
+    Serial.println("[net] and use your PRODUCTION vercel.app URL in secrets.h.");
+  }
 
   if (code == 200) {
     out.text = urlDecode(s_http.header("X-Answer-Text"));

--- a/questionbox/server/lib/ai/stt.ts
+++ b/questionbox/server/lib/ai/stt.ts
@@ -4,20 +4,31 @@ import { getOpenAI } from "./openai";
 /**
  * Speech-to-text. Transcribes the child's recorded WAV to text.
  * Audio is used transiently here and never persisted.
+ *
+ * Defaults to whisper-1 (available on every OpenAI account). Falls back across
+ * models on error so a single model's availability can't break the box.
  */
 export async function transcribe(audio: ArrayBuffer | Buffer): Promise<string> {
   const openai = getOpenAI();
-  const model = process.env.STT_MODEL || "gpt-4o-mini-transcribe";
   const buf = Buffer.isBuffer(audio) ? audio : Buffer.from(audio);
-  const file = await toFile(buf, "question.wav", { type: "audio/wav" });
 
-  const res = await openai.audio.transcriptions.create({
-    file,
-    model,
-    response_format: "text",
-  });
+  const primary = process.env.STT_MODEL || "whisper-1";
+  const models = [primary, "gpt-4o-mini-transcribe", "whisper-1"].filter(
+    (m, i, a) => a.indexOf(m) === i,
+  );
 
-  // With response_format "text" the SDK returns a string; be defensive anyway.
-  const text = typeof res === "string" ? res : ((res as { text?: string }).text ?? "");
-  return text.trim();
+  let lastErr: unknown;
+  for (const model of models) {
+    try {
+      // Recreate the file each attempt (the upload stream is consumed on use).
+      const file = await toFile(buf, "question.wav", { type: "audio/wav" });
+      const res = await openai.audio.transcriptions.create({ file, model, response_format: "text" });
+      const text = typeof res === "string" ? res : ((res as { text?: string }).text ?? "");
+      return text.trim();
+    } catch (e) {
+      lastErr = e;
+      console.error(`[stt] model "${model}" failed:`, (e as Error).message);
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error("transcription failed");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bundles the fixes since the loop reached `status 200`:

## 1. Speech-to-text made robust (fixes the "trouble hearing" answer)
The server was returning its STT-error fallback because the transcription model wasn't available on the account. STT now **defaults to `whisper-1`** (on every account) and **falls back across models**, logging which failed and why.

## 2. Boot test tone (to diagnose "no sound")
Playback ran (`[spk] playback done`) but nothing was heard. Added **`Speaker_TestBeep()`** at boot — a raw 0.5s tone that bypasses software volume — to tell whether it's the **speaker/amp/volume** or our playback path.

## 3. Vercel Deployment Protection handling (the earlier 302)
Clear log hint on any 3xx, plus an optional `VERCEL_BYPASS_SECRET` header. (The real fix was turning Vercel Deployment Protection off, which you did.)

Server: 90 tests pass. Firmware builds (RAM 43%, flash 21.3%).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

