### PR TITLE
Fix flaky DNS (force public DNS) + strip trailing slash in server URL

### DIFF
--- a/questionbox/firmware/src/net/wifi_conn.cpp
+++ b/questionbox/firmware/src/net/wifi_conn.cpp
@@ -2,6 +2,19 @@
 #include "device_config.h"
 #include <Arduino.h>
 #include <WiFi.h>
+#include "lwip/dns.h"
+
+// The device's DHCP-provided DNS was intermittently failing to resolve the
+// server. Force reliable public DNS servers (Google + Cloudflare).
+static void set_public_dns()
+{
+  ip_addr_t d1;
+  ip_addr_t d2;
+  IP_ADDR4(&d1, 8, 8, 8, 8);
+  IP_ADDR4(&d2, 1, 1, 1, 1);
+  dns_setserver(0, &d1);
+  dns_setserver(1, &d2);
+}
 
 bool WiFiConn_IsConnected()
 {
@@ -26,7 +39,8 @@ bool WiFiConn_Connect(uint32_t timeout_ms)
   }
 
   if (WiFiConn_IsConnected()) {
-    Serial.printf("[wifi] connected, IP = %s\n", WiFi.localIP().toString().c_str());
+    set_public_dns();
+    Serial.printf("[wifi] connected, IP = %s (DNS 8.8.8.8/1.1.1.1)\n", WiFi.localIP().toString().c_str());
     return true;
   }
   Serial.println("[wifi] connection FAILED");

--- a/questionbox/firmware/src/net/wonder_client.cpp
+++ b/questionbox/firmware/src/net/wonder_client.cpp
@@ -69,7 +69,10 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
   Serial.printf("[net] free heap %u, largest block %u\n",
                 (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMaxAllocHeap());
 
-  String url = String(SERVER_BASE_URL) + "/api/ask";
+  // Strip any trailing '/' so we don't POST to "...app//api/ask" (Vercel 308s on that).
+  String base = SERVER_BASE_URL;
+  while (base.length() > 0 && base.endsWith("/")) base.remove(base.length() - 1);
+  String url = base + "/api/ask";
   static const char *collect[] = {"X-Answer-Text", "X-Answer-Mode", "X-Is-Spelling", "X-Spell-Word"};
 
   // Retry a few times so a transient DNS/TLS hiccup doesn't drop the question.

--- a/questionbox/firmware/src/net/wonder_client.cpp
+++ b/questionbox/firmware/src/net/wonder_client.cpp
@@ -70,29 +70,37 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
                 (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMaxAllocHeap());
 
   String url = String(SERVER_BASE_URL) + "/api/ask";
-  if (!s_http.begin(s_tls, url)) {
-    Serial.println("[net] http.begin failed");
-    return -1;
-  }
-  s_open = true;
-
-  s_http.setConnectTimeout(20000);
-  s_http.setTimeout(20000);
-  s_http.addHeader("Content-Type", "audio/wav");
-  s_http.addHeader("Authorization", String("Bearer ") + DEVICE_TOKEN);
-
-  // Optional: bypass Vercel Deployment Protection without disabling it.
-  if (sizeof(VERCEL_BYPASS_SECRET) > 1) {
-    s_http.addHeader("x-vercel-protection-bypass", VERCEL_BYPASS_SECRET);
-    s_http.addHeader("x-vercel-set-bypass-cookie", "true");
-  }
-
   static const char *collect[] = {"X-Answer-Text", "X-Answer-Mode", "X-Is-Spelling", "X-Spell-Word"};
-  s_http.collectHeaders(collect, 4);
 
-  Serial.printf("[net] POST %s (%u bytes)\n", url.c_str(), (unsigned)len);
-  int code = s_http.POST((uint8_t *)wav, len);
-  Serial.printf("[net] status %d\n", code);
+  // Retry a few times so a transient DNS/TLS hiccup doesn't drop the question.
+  int code = -1;
+  for (int attempt = 1; attempt <= 3; attempt++) {
+    if (!s_http.begin(s_tls, url)) {
+      Serial.println("[net] http.begin failed");
+      delay(600);
+      continue;
+    }
+    s_open = true;
+    s_http.setConnectTimeout(20000);
+    s_http.setTimeout(20000);
+    s_http.addHeader("Content-Type", "audio/wav");
+    s_http.addHeader("Authorization", String("Bearer ") + DEVICE_TOKEN);
+    if (sizeof(VERCEL_BYPASS_SECRET) > 1) {
+      s_http.addHeader("x-vercel-protection-bypass", VERCEL_BYPASS_SECRET);
+      s_http.addHeader("x-vercel-set-bypass-cookie", "true");
+    }
+    s_http.collectHeaders(collect, 4);
+
+    Serial.printf("[net] POST %s (%u bytes) [try %d]\n", url.c_str(), (unsigned)len, attempt);
+    code = s_http.POST((uint8_t *)wav, len);
+    Serial.printf("[net] status %d\n", code);
+
+    if (code > 0) break;   // got an HTTP response; stop retrying
+    s_http.end();          // transport error (DNS/TLS) -> reset and retry
+    s_tls.stop();
+    s_open = false;
+    delay(900);
+  }
 
   if (code >= 300 && code < 400) {
     Serial.println("[net] server redirected (3xx). This is almost always Vercel");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Your production URL is correct and healthy — I verified from the internet that `wonderbox-mu.vercel.app/api/ask` returns **200** with `aiConfigured:true`. Two device-side bugs remained:

1. **Flaky DNS on the device** (`DNS Failed … error -54`). The URL resolves fine everywhere else, so the device's DHCP DNS was the problem. Now the firmware sets **public DNS (8.8.8.8 / 1.1.1.1)** right after Wi-Fi connects.
2. **Double slash** — a trailing `/` in `SERVER_BASE_URL` produced `…app//api/ask`, which Vercel **308-redirects** (I confirmed: `//api/ask` → 308, `/api/ask` → 200). The firmware now strips trailing slashes before appending `/api/ask`, so it's robust to how you type the URL.

Also includes the earlier 3× connection retry for transient hiccups.

Builds clean (RAM 43%, flash 21.3%). After flashing, the request should reach the server reliably and return a real answer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

