### PR TITLE
Diagnose transcription (X-Debug) + avg mic downmix + smiling-while-speaking + louder beep

### DIFF
--- a/questionbox/firmware/src/audio/mic.cpp
+++ b/questionbox/firmware/src/audio/mic.cpp
@@ -79,7 +79,9 @@ bool Mic_Poll()
     int16_t *in = (int16_t *)tmp;
     int16_t *out = (int16_t *)(s_buf + WAV_HEADER_LEN);
     for (int i = 0; i < frames && s_count < REC_MAX_SAMPLES; i++) {
-      int32_t mono = (int32_t)in[i * 2] + (int32_t)in[i * 2 + 1];  // L + R
+      // Average the two slots (not sum) so a mic that duplicates onto both
+      // channels doesn't clip/distort the recording.
+      int32_t mono = ((int32_t)in[i * 2] + (int32_t)in[i * 2 + 1]) / 2;
       out[s_count++] = clamp16(mono);
     }
   }

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -67,7 +67,7 @@ void Speaker_TestBeep()
     for (int i = 0; i < cnt; i++) {
       float t = (float)(done + i) / rate;
       float env = sinf(3.14159265f * (done + i) / total);   // gentle fade in/out
-      float s = sinf(2.0f * 3.14159265f * 700.0f * t) * 0.35f * env;
+      float s = sinf(2.0f * 3.14159265f * 700.0f * t) * 0.6f * env;   // louder for audibility
       int16_t v = (int16_t)(s * 32767);
       buf[i * 2] = v;
       buf[i * 2 + 1] = v;

--- a/questionbox/firmware/src/net/wonder_client.cpp
+++ b/questionbox/firmware/src/net/wonder_client.cpp
@@ -73,7 +73,7 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
   String base = SERVER_BASE_URL;
   while (base.length() > 0 && base.endsWith("/")) base.remove(base.length() - 1);
   String url = base + "/api/ask";
-  static const char *collect[] = {"X-Answer-Text", "X-Answer-Mode", "X-Is-Spelling", "X-Spell-Word"};
+  static const char *collect[] = {"X-Answer-Text", "X-Answer-Mode", "X-Is-Spelling", "X-Spell-Word", "X-Debug"};
 
   // Retry a few times so a transient DNS/TLS hiccup doesn't drop the question.
   int code = -1;
@@ -92,7 +92,7 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
       s_http.addHeader("x-vercel-protection-bypass", VERCEL_BYPASS_SECRET);
       s_http.addHeader("x-vercel-set-bypass-cookie", "true");
     }
-    s_http.collectHeaders(collect, 4);
+    s_http.collectHeaders(collect, 5);
 
     Serial.printf("[net] POST %s (%u bytes) [try %d]\n", url.c_str(), (unsigned)len, attempt);
     code = s_http.POST((uint8_t *)wav, len);
@@ -110,6 +110,9 @@ int WonderClient_Ask(const uint8_t *wav, size_t len, AnswerInfo &out)
     Serial.println("[net] Deployment Protection. Fix: turn it OFF (or 'Only Preview')");
     Serial.println("[net] and use your PRODUCTION vercel.app URL in secrets.h.");
   }
+
+  String dbg = s_http.header("X-Debug");
+  if (dbg.length()) Serial.printf("[net] debug: %s\n", urlDecode(dbg).c_str());
 
   if (code == 200) {
     out.text = urlDecode(s_http.header("X-Answer-Text"));

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -193,13 +193,13 @@ void Face_SetState(WbState state)
 
   show(eye_l, face);
   show(eye_r, face);
-  show(smile, face && !speak);        // smile for idle/listening/thinking
-  show(talk, speak);                  // open mouth only while speaking
+  show(smile, face);                  // keep smiling in every face state (incl. speaking)
+  show(talk, false);                  // retired the awkward open mouth
   for (int i = 0; i < 3; i++) show(comets[i], glow);
   show(letter_lbl, spell);
   show(word_lbl, spell);
 
-  if (face && !speak) set_smile(listen);   // big happy smile while listening
+  if (face) set_smile(listen || speak);    // big happy smile while listening AND speaking
 
   uint32_t now = lv_tick_get();
   blink_start_ms = 0;
@@ -314,17 +314,12 @@ void Face_Tick(void)
       spin_edge(t * 75.0f, 110);             // slow, gentle
       break;
 
-    case WB_SPEAKING: {
-      gaze_tx = 0; gaze_ty = 0;
-      update_gaze(now, false);
+    case WB_SPEAKING:
+      // Stay smiling and lively while talking: eyes look around, edge flows.
+      update_gaze(now, true);
       place_eyes(blink_factor(now));
-      float m = 0.5f + 0.5f * sinf(t * 11.0f);
-      int h = 16 + (int)(40 * m);
-      lv_obj_set_size(talk, 80, h);
-      lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY);
-      spin_edge(t * 130.0f, 170);            // medium
+      spin_edge(t * 130.0f, 190);
       break;
-    }
 
     case WB_SPELLING:
       if (spell_len > 0 && now - spell_last_ms >= SPELL_STEP_MS) {

--- a/questionbox/server/app/api/ask/route.ts
+++ b/questionbox/server/app/api/ask/route.ts
@@ -55,9 +55,13 @@ export async function POST(request: Request): Promise<Response> {
   try {
     question = await transcribe(audio);
   } catch (e) {
-    console.error("[ask] STT failed:", e);
+    const msg = String((e as Error)?.message ?? e);
+    console.error("[ask] STT failed:", msg);
     const text = troubleMessage();
-    return buildAnswerResponse({ text, mode: "deferred", isSpelling: false, wav: await ttsOrChime(text) });
+    return buildAnswerResponse(
+      { text, mode: "deferred", isSpelling: false, wav: await ttsOrChime(text) },
+      "stt:" + msg,
+    );
   }
 
   // 2) Safety pipeline (2 gates + deterministic checks) -> answer text.
@@ -78,7 +82,15 @@ export async function POST(request: Request): Promise<Response> {
   console.log(`[ask] q="${question}" -> mode=${result.mode} cat=${result.category ?? "-"}`);
 
   // 4) Text-to-speech.
-  const wav = await ttsOrChime(result.text);
+  let ttsDebug = "";
+  let wav: Buffer;
+  try {
+    wav = await synthesize(result.text);
+  } catch (e) {
+    ttsDebug = "tts:" + String((e as Error)?.message ?? e);
+    console.error("[ask] TTS failed:", ttsDebug);
+    wav = generateChimeWav();
+  }
 
   const answer: WonderAnswer = {
     text: result.text,
@@ -87,7 +99,8 @@ export async function POST(request: Request): Promise<Response> {
     spellWord: result.spellWord,
     wav,
   };
-  return buildAnswerResponse(answer);
+  const debug = ttsDebug || `q="${question}" mode=${result.mode}`;
+  return buildAnswerResponse(answer, debug);
 }
 
 export function GET(): Response {

--- a/questionbox/server/lib/answer.ts
+++ b/questionbox/server/lib/answer.ts
@@ -33,7 +33,7 @@ export const ANSWER_HEADERS = {
  * Build the HTTP response: WAV bytes as the body, answer text in headers.
  * `Cache-Control: no-store` because answers are per-child and never cached.
  */
-export function buildAnswerResponse(a: WonderAnswer): Response {
+export function buildAnswerResponse(a: WonderAnswer, debug?: string): Response {
   const headers = new Headers();
   headers.set("Content-Type", "audio/wav");
   headers.set("Content-Length", String(a.wav.length));
@@ -42,10 +42,11 @@ export function buildAnswerResponse(a: WonderAnswer): Response {
   headers.set(ANSWER_HEADERS.mode, a.mode);
   headers.set(ANSWER_HEADERS.isSpelling, a.isSpelling ? "1" : "0");
   headers.set(ANSWER_HEADERS.spellWord, encodeURIComponent(a.spellWord ?? ""));
+  if (debug) headers.set("X-Debug", encodeURIComponent(debug.slice(0, 400)));
   // Let non-device clients (e.g. a browser fetch, tests) read the custom headers.
   headers.set(
     "Access-Control-Expose-Headers",
-    Object.values(ANSWER_HEADERS).join(", "),
+    [...Object.values(ANSWER_HEADERS), "X-Debug"].join(", "),
   );
 
   // Copy into a fresh Uint8Array so the Web Response gets a clean ArrayBuffer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Billing is fixed (STT no longer throws). Remaining: valid questions get "refused", which points to a **garbled transcription**, plus no audible sound, plus the awkward speaking mouth.

## Server
- **`X-Debug` response header** carries the transcription (`q="..."`) and any STT/TTS error, so we can finally see what the mic audio transcribes to.

## Firmware
- **Logs the transcription** (`[net] debug: q="..."`) so you can paste it — this tells us if the mic audio is clean or garbled.
- **Mic downmix averages L+R** instead of summing, to avoid clipping/distortion (a likely cause of garbled transcription).
- **Smiles while speaking** — removed the awkward open/close mouth; the face now keeps its big happy smile with lively, wandering eyes while it responds (per request).
- **Louder boot beep** to help confirm the speaker path.

After merging (server auto-deploys) + re-flashing, ask "how far away is the sun" and the log will show `[net] debug: q="..."`. If `q` is the correct sentence → I'll fix the classifier; if it's garbled → I'll fix the mic capture. Builds clean (RAM 43%, flash 21.3%).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

