### PR TITLE
Bake production server URL into firmware default (end the stale-URL reverts)

### DIFF
--- a/questionbox/firmware/include/device_config.h
+++ b/questionbox/firmware/include/device_config.h
@@ -18,8 +18,12 @@
 #ifndef WIFI_PASSWORD
 #define WIFI_PASSWORD ""
 #endif
+// Default to the production server. If your secrets.h does NOT define
+// SERVER_BASE_URL, this correct URL is used automatically (so it can't get
+// stuck on a stale per-deployment URL). To point elsewhere, define it in
+// secrets.h.
 #ifndef SERVER_BASE_URL
-#define SERVER_BASE_URL ""
+#define SERVER_BASE_URL "https://wonderbox-mu.vercel.app"
 #endif
 #ifndef DEVICE_TOKEN
 #define DEVICE_TOKEN ""

--- a/questionbox/firmware/include/secrets.h.example
+++ b/questionbox/firmware/include/secrets.h.example
@@ -11,9 +11,12 @@
 #define WIFI_SSID       "your-wifi-name"
 #define WIFI_PASSWORD   "your-wifi-password"
 
-// The WonderBox server base URL (your Vercel deployment), e.g.
-// "https://wonderbox-yourname.vercel.app"
-#define SERVER_BASE_URL "https://your-server.vercel.app"
+// The WonderBox server base URL — your Vercel PRODUCTION domain (the short one,
+// no random deployment hash), e.g. "https://wonderbox-mu.vercel.app".
+// IMPORTANT: use the production domain, NOT a "...-<random>-...vercel.app"
+// deployment URL (those change/expire). If you leave this line out entirely,
+// the firmware falls back to the built-in production default.
+#define SERVER_BASE_URL "https://wonderbox-mu.vercel.app"
 
 // Shared secret so only your box can call the server. Generate a long random
 // value (e.g. `openssl rand -hex 32`) and set the SAME value in the server env.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The device kept getting flashed with a stale per-deployment URL (`…-i08tmpmbs-…`) in `secrets.h`, which fails DNS and blocks every request. This sets the built-in default `SERVER_BASE_URL` to the production domain **`https://wonderbox-mu.vercel.app`**, so if the `SERVER_BASE_URL` line is simply removed from `secrets.h`, the firmware uses the correct URL automatically and can't revert.

The user's log also reported a faint speaker squeal → the speaker is electrically alive; the missing answers were purely downstream of the failing URL.

Builds clean (RAM 43%, flash 21.3%).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

