### PR TITLE
mic_test: add I2C scan to detect board revision (V1 vs V2 audio codecs)

### DIFF
--- a/questionbox/tools/mic_test/src/main.cpp
+++ b/questionbox/tools/mic_test/src/main.cpp
@@ -13,14 +13,42 @@
  *****************************************************************************/
 #include <Arduino.h>
 #include <ESP_I2S.h>
+#include <Wire.h>
 
 static I2SClass i2s;
 static bool s_ok = false;
+
+// Scan the I2C bus and report which audio chips are present. This tells us the
+// board revision: V1 (PCM5101 + MEMS mic) vs V2 (ES8311 + ES7210 codecs).
+static void scanI2C() {
+  Wire.begin(11 /*SDA*/, 10 /*SCL*/);
+  Serial.println("--- I2C scan ---");
+  int found = 0;
+  bool es8311 = false, es7210 = false;
+  for (uint8_t a = 1; a < 0x7F; a++) {
+    Wire.beginTransmission(a);
+    if (Wire.endTransmission() == 0) {
+      Serial.printf("  found 0x%02X\n", a);
+      found++;
+      if (a == 0x18) es8311 = true;                 // ES8311 codec
+      if (a == 0x40 || a == 0x41 || a == 0x42 || a == 0x43) es7210 = true; // ES7210 ADC
+    }
+  }
+  if (found == 0) Serial.println("  (no I2C devices found)");
+  if (es8311 || es7210) {
+    Serial.println(">>> This looks like a V2 board (ES8311/ES7210 codecs). The");
+    Serial.println(">>> mic/speaker need I2C codec setup - tell your assistant!");
+  } else {
+    Serial.println(">>> No audio codecs found -> looks like a V1 board (PCM5101 + MEMS mic).");
+  }
+  Serial.println("----------------");
+}
 
 void setup() {
   Serial.begin(115200);
   delay(600);
   Serial.println("\n=== WonderBox MIC TEST (ESP_I2S, no PSRAM) ===");
+  scanI2C();
 
   // SDOUT = -1 (we only receive), MCLK = -1 (not needed for this mic).
   i2s.setPins(15 /*BCK*/, 2 /*WS*/, -1 /*SDOUT*/, 39 /*DIN*/, -1 /*MCLK*/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The mic reads **pure zeros on two independent drivers** (legacy + ESP_I2S) with the correct V1 pins, and the driver *is* running (it prints zeros, not errors). That pattern — plus the earlier speaker "squeal" — points at a possible **board-revision mismatch**: if this is a **V2** board (ES8311 + ES7210 codecs), the mic and speaker must be configured over **I2C** first, which our V1-assuming code never does.

This adds an **I2C scan** to the mic test that prints all devices and specifically flags **ES8311 (0x18)** / **ES7210 (0x40–0x43)**:
- Codecs present → **V2 board** → I'll rewrite the audio layer to configure the codecs over I2C (this would explain both the silent mic and squealing speaker).
- No codecs → **V1 board** → the mic is genuinely faulty → replacement.

One quick run of this settles the direction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

