### PR TITLE
mic_test: V2 audio — configure ES7210 codec + shared I2S (MCLK/BCK/WS)

### DIFF
--- a/questionbox/tools/mic_test/src/es7210.cpp
+++ b/questionbox/tools/mic_test/src/es7210.cpp
@@ -1,0 +1,373 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <inttypes.h>
+#include "es7210.h"
+#include "es7210_reg.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "Wire.h"
+
+const static char *TAG = "ES7210";
+
+#define IS_ES7210_I2S_FMT(val) (((val)==ES7210_I2S_FMT_I2S) || ((val)==ES7210_I2S_FMT_LJ) || \
+        ((val)==ES7210_I2S_FMT_DSP_A) || ((val)==ES7210_I2S_FMT_DSP_B))
+
+#define IS_ES7210_I2S_BITS(val) (((val)==ES7210_I2S_BITS_24B) || ((val)==ES7210_I2S_BITS_20B) || \
+        ((val)==ES7210_I2S_BITS_18B) || ((val)==ES7210_I2S_BITS_16B) || ((val)==ES7210_I2S_BITS_32B))
+
+#define IS_ES7210_MIC_GAIN(val) (((val) >= ES7210_MIC_GAIN_0DB) && ((val) <= ES7210_MIC_GAIN_37_5DB))
+
+#define IS_ES7210_MIC_BIAS(val) (((val)==ES7210_MIC_BIAS_2V18) || ((val)==ES7210_MIC_BIAS_2V26) || \
+        ((val)==ES7210_MIC_BIAS_2V36) || ((val)==ES7210_MIC_BIAS_2V45) || ((val)==ES7210_MIC_BIAS_2V55) || \
+        ((val)==ES7210_MIC_BIAS_2V66) || ((val)==ES7210_MIC_BIAS_2V78) || ((val)==ES7210_MIC_BIAS_2V87))
+
+#define ES7210_WRITE_REG(reg_addr, reg_value) do { \
+    ESP_RETURN_ON_ERROR(es7210_write_reg(handle, (reg_addr), (reg_value)), \
+                        TAG, "i2c communication error while writing "#reg_addr); \
+} while(0)
+
+struct es7210_dev_t {
+    i2c_port_t  i2c_port;
+    uint8_t     i2c_addr;
+};
+
+/**
+ * @brief Clock coefficient structure
+ *
+ */
+typedef struct {
+    uint32_t mclk;            /*!< mclk frequency */
+    uint32_t lrck;            /*!< lrck */
+    uint8_t  ss_ds;           /*!< not used */
+    uint8_t  adc_div;         /*!< adcclk divider */
+    uint8_t  dll;             /*!< dll_bypass */
+    uint8_t  doubler;         /*!< doubler enable */
+    uint8_t  osr;             /*!< adc osr */
+    uint8_t  mclk_src;        /*!< select mclk  source */
+    uint32_t lrck_h;          /*!< The high 4 bits of lrck */
+    uint32_t lrck_l;          /*!< The low 8 bits of lrck */
+} coeff_div_t;
+
+/**
+ * @brief ES7210 clock coefficient lookup table
+ *
+ */
+static const coeff_div_t es7210_coeff_div[] = {
+//    mclk      lrck    ss_ds adc_div  dll  doubler osr  mclk_src  lrckh   lrckl
+    /* 8k */
+    {12288000,  8000,  0x00,  0x03,  0x01,  0x00,  0x20,  0x00,    0x06,  0x00},
+    {16384000,  8000,  0x00,  0x04,  0x01,  0x00,  0x20,  0x00,    0x08,  0x00},
+    {19200000,  8000,  0x00,  0x1e,  0x00,  0x01,  0x28,  0x00,    0x09,  0x60},
+    {4096000,   8000,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+
+    /* 11.025k */
+    {11289600,  11025,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x01,  0x00},
+
+    /* 12k */
+    {12288000,  12000,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x04,  0x00},
+    {19200000,  12000,  0x00,  0x14,  0x00,  0x01,  0x28,  0x00,    0x06,  0x40},
+
+    /* 16k */
+    {4096000,   16000,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},
+    {19200000,  16000,  0x00,  0x0a,  0x00,  0x00,  0x1e,  0x00,    0x04,  0x80},
+    {16384000,  16000,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x04,  0x00},
+    {12288000,  16000,  0x00,  0x03,  0x01,  0x01,  0x20,  0x00,    0x03,  0x00},
+
+    /* 22.05k */
+    {11289600,  22050,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+
+    /* 24k */
+    {12288000,  24000,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+    {19200000,  24000,  0x00,  0x0a,  0x00,  0x01,  0x28,  0x00,    0x03,  0x20},
+
+    /* 32k */
+    {12288000,  32000,  0x00,  0x03,  0x00,  0x00,  0x20,  0x00,    0x01,  0x80},
+    {16384000,  32000,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+    {19200000,  32000,  0x00,  0x05,  0x00,  0x00,  0x1e,  0x00,    0x02,  0x58},
+
+    /* 44.1k */
+    {11289600,  44100,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},
+
+    /* 48k */
+    {12288000,  48000,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},
+    {19200000,  48000,  0x00,  0x05,  0x00,  0x01,  0x28,  0x00,    0x01,  0x90},
+
+    /* 64k */
+    {16384000,  64000,  0x01,  0x01,  0x01,  0x00,  0x20,  0x00,    0x01,  0x00},
+    {19200000,  64000,  0x00,  0x05,  0x00,  0x01,  0x1e,  0x00,    0x01,  0x2c},
+
+    /* 88.2k */
+    {11289600,  88200,  0x01,  0x01,  0x01,  0x01,  0x20,  0x00,    0x00,  0x80},
+
+    /* 96k */
+    {12288000,  96000,  0x01,  0x01,  0x01,  0x01,  0x20,  0x00,    0x00,  0x80},
+    {19200000,  96000,  0x01,  0x05,  0x00,  0x01,  0x28,  0x00,    0x00,  0xc8},
+};
+
+/**
+ * @brief Get coefficient from coefficient table
+ *
+ * @param mclk Desired MCLK value
+ * @param lrck Desired LRCK vaule
+ * @return Coefficient struct, NULL if desired value cannot be achieved
+ */
+static const coeff_div_t *es7210_get_coeff(uint32_t mclk, uint32_t lrck)
+{
+    for (int i = 0; i < sizeof(es7210_coeff_div) / sizeof(coeff_div_t); i++) {
+        if (es7210_coeff_div[i].lrck == lrck && es7210_coeff_div[i].mclk == mclk) {
+            return &es7210_coeff_div[i];
+        }
+    }
+    return NULL;
+}
+
+
+static bool i2c_reg8_write(uint8_t dev_addr, uint8_t reg_addr, uint8_t *data, uint8_t len) {
+  uint8_t error;
+  Wire.beginTransmission(dev_addr);
+  Wire.write(reg_addr);
+  for (int i = 0; i < len; i++) {
+    Wire.write(*data++);
+  }
+  error = Wire.endTransmission(true);
+  if (error) {
+    printf("endTransmission: %u\n", error);
+    return false;
+  }
+  return true;
+}
+
+
+
+
+static esp_err_t es7210_write_reg(es7210_dev_handle_t handle, uint8_t reg_addr, uint8_t reg_val)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle");
+    if (i2c_reg8_write(handle->i2c_addr, reg_addr, &reg_val, 1))
+      return ESP_OK;
+    else
+      return ESP_FAIL;
+
+
+
+//     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle");
+//     esp_err_t ret = ESP_OK;
+
+//     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+//     ESP_GOTO_ON_FALSE(cmd, ESP_ERR_NO_MEM, err, TAG, "memory allocation for i2c cmd handle failed");
+
+//     ESP_GOTO_ON_ERROR(i2c_master_start(cmd), err, TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd, handle->i2c_addr << 1 | I2C_MASTER_WRITE, true),
+//                       err, TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd, reg_addr, true), err,
+//                       TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd, reg_val, true), err,
+//                       TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_stop(cmd), err, TAG, "error while appending i2c command");
+
+//     ESP_GOTO_ON_ERROR(i2c_master_cmd_begin(handle->i2c_port, cmd, pdMS_TO_TICKS(1000)),
+//                       err, TAG, "error while writing register");
+// err:
+//     if (cmd) {
+//         i2c_cmd_link_delete(cmd);
+//     }
+//     return ret;
+}
+
+static esp_err_t es7210_set_i2s_format(es7210_dev_handle_t handle, es7210_i2s_fmt_t i2s_format,
+                                       es7210_i2s_bits_t bit_width, bool tdm_enable)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(IS_ES7210_I2S_FMT(i2s_format), ESP_ERR_INVALID_ARG, TAG, "invalid i2s format argument");
+    ESP_RETURN_ON_FALSE(IS_ES7210_I2S_BITS(bit_width), ESP_ERR_INVALID_ARG, TAG, "invalid i2s bit width argument");
+
+    uint8_t reg_val = 0;
+
+    switch (bit_width) {
+    case ES7210_I2S_BITS_16B:
+        reg_val = 0x60;
+        break;
+    case ES7210_I2S_BITS_18B:
+        reg_val = 0x40;
+        break;
+    case ES7210_I2S_BITS_20B:
+        reg_val = 0x20;
+        break;
+    case ES7210_I2S_BITS_24B:
+        reg_val = 0x00;
+        break;
+    case ES7210_I2S_BITS_32B:
+        reg_val = 0x80;
+        break;
+    default:
+        abort();
+    }
+    ES7210_WRITE_REG(ES7210_SDP_INTERFACE1_REG11, i2s_format | reg_val);
+
+    const char *mode_str = NULL;
+    switch (i2s_format) {
+    case ES7210_I2S_FMT_I2S:
+        reg_val = 0x02;
+        mode_str = "standard i2s";
+        break;
+    case ES7210_I2S_FMT_LJ:
+        reg_val = 0x02;
+        mode_str = "left justify";
+        break;
+    case ES7210_I2S_FMT_DSP_A:
+        reg_val = 0x01;
+        mode_str = "DSP-A";
+        break;
+    case ES7210_I2S_FMT_DSP_B:
+        reg_val = 0x01;
+        mode_str = "DSP-B";
+        break;
+    default:
+        abort();
+    }
+
+    if (tdm_enable) { // enable 1xFS TDM
+        ES7210_WRITE_REG(ES7210_SDP_INTERFACE2_REG12, reg_val);
+    } else {
+        ES7210_WRITE_REG(ES7210_SDP_INTERFACE2_REG12, 0x00);
+    }
+
+    ESP_LOGI(TAG, "format: %s, bit width: %d, tdm mode %s", mode_str, bit_width, tdm_enable ? "enabled" : "disabled");
+    return ESP_OK;
+}
+
+static esp_err_t es7210_set_i2s_sample_rate(es7210_dev_handle_t handle, uint32_t sample_rate_hz, uint32_t mclk_ratio)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+
+    uint32_t mclk_freq_hz = sample_rate_hz * mclk_ratio;
+    const coeff_div_t *coeff_div = es7210_get_coeff(mclk_freq_hz, sample_rate_hz);
+    ESP_RETURN_ON_FALSE(coeff_div, ESP_ERR_NOT_SUPPORTED, TAG,
+                        "unable to set %"PRIu32"Hz sample rate with %"PRIu32"Hz MCLK", sample_rate_hz, mclk_freq_hz);
+    /* Set osr */
+    ES7210_WRITE_REG(ES7210_OSR_REG07, coeff_div->osr);
+    /* Set adc_div & doubler & dll */
+    ES7210_WRITE_REG(ES7210_MAINCLK_REG02, (coeff_div->adc_div) | (coeff_div->doubler << 6) | (coeff_div->dll << 7));
+    /* Set lrck */
+    ES7210_WRITE_REG(ES7210_LRCK_DIVH_REG04, coeff_div->lrck_h);
+    ES7210_WRITE_REG(ES7210_LRCK_DIVL_REG05, coeff_div->lrck_l);
+
+    ESP_LOGI(TAG, "sample rate: %"PRIu32"Hz, mclk frequency: %"PRIu32"Hz", sample_rate_hz, mclk_freq_hz);
+    return ESP_OK;
+}
+
+static esp_err_t es7210_set_mic_gain(es7210_dev_handle_t handle, es7210_mic_gain_t mic_gain)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(IS_ES7210_MIC_GAIN(mic_gain), ESP_ERR_INVALID_ARG, TAG, "invalid mic gain value");
+
+    ES7210_WRITE_REG(ES7210_MIC1_GAIN_REG43, mic_gain | 0x10);
+    ES7210_WRITE_REG(ES7210_MIC2_GAIN_REG44, mic_gain | 0x10);
+    ES7210_WRITE_REG(ES7210_MIC3_GAIN_REG45, mic_gain | 0x10);
+    ES7210_WRITE_REG(ES7210_MIC4_GAIN_REG46, mic_gain | 0x10);
+
+    return ESP_OK;
+}
+
+static esp_err_t es7210_set_mic_bias(es7210_dev_handle_t handle, es7210_mic_bias_t mic_bias)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(IS_ES7210_MIC_BIAS(mic_bias), ESP_ERR_INVALID_ARG, TAG, "invalid mic bias value");
+
+    ES7210_WRITE_REG(ES7210_MIC12_BIAS_REG41, mic_bias);
+    ES7210_WRITE_REG(ES7210_MIC34_BIAS_REG42, mic_bias);
+
+    return ESP_OK;
+}
+
+esp_err_t es7210_new_codec(const es7210_i2c_config_t *i2c_conf, es7210_dev_handle_t *handle_out)
+{
+    ESP_RETURN_ON_FALSE(i2c_conf, ESP_ERR_INVALID_ARG, TAG, "invalid device config pointer");
+    ESP_RETURN_ON_FALSE(handle_out, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+
+    struct es7210_dev_t *handle = (struct es7210_dev_t *)calloc(1, sizeof(struct es7210_dev_t));
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_NO_MEM, TAG, "memory allocation for device handler failed");
+
+    handle->i2c_port = i2c_conf->i2c_port;
+    handle->i2c_addr = i2c_conf->i2c_addr;
+
+    *handle_out = handle;
+    return ESP_OK;
+}
+
+esp_err_t es7210_del_codec(es7210_dev_handle_t handle)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+
+    free(handle);
+
+    return ESP_OK;
+}
+
+esp_err_t es7210_config_codec(es7210_dev_handle_t handle, const es7210_codec_config_t *codec_conf)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(codec_conf, ESP_ERR_INVALID_ARG, TAG, "invalid codec config pointer");
+
+    /* Perform software reset */
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0xFF);
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0x32);
+    /* Set the initialization time when device powers up */
+    ES7210_WRITE_REG(ES7210_TIME_CONTROL0_REG09, 0x30);
+    ES7210_WRITE_REG(ES7210_TIME_CONTROL1_REG0A, 0x30);
+    /* Configure HPF for ADC1-4 */
+    ES7210_WRITE_REG(ES7210_ADC12_HPF1_REG23, 0x2A);
+    ES7210_WRITE_REG(ES7210_ADC12_HPF2_REG22, 0x0A);
+    ES7210_WRITE_REG(ES7210_ADC34_HPF1_REG21, 0x2A);
+    ES7210_WRITE_REG(ES7210_ADC34_HPF2_REG20, 0x0A);
+    /* Set bits per sample to 16, data protocal to I2S, enable 1xFS TDM */
+    ESP_RETURN_ON_ERROR(es7210_set_i2s_format(handle, codec_conf->i2s_format, codec_conf->bit_width,
+                        codec_conf->flags.tdm_enable), TAG, "error while setting i2s format");
+    /* Configure analog power and VMID voltage */
+    ES7210_WRITE_REG(ES7210_ANALOG_REG40, 0xC3);
+    /* Set MIC14 bias to 2.87V */
+    ESP_RETURN_ON_ERROR(es7210_set_mic_bias(handle, codec_conf->mic_bias), TAG, "error while setting mic bias");
+    /* Set MIC1-4 gain to 30dB */
+    ESP_RETURN_ON_ERROR(es7210_set_mic_gain(handle, codec_conf->mic_gain), TAG, "error while setting mic gain");
+    /* Power on MIC1-4 */
+    ES7210_WRITE_REG(ES7210_MIC1_POWER_REG47, 0x08);
+    ES7210_WRITE_REG(ES7210_MIC2_POWER_REG48, 0x08);
+    ES7210_WRITE_REG(ES7210_MIC3_POWER_REG49, 0x08);
+    ES7210_WRITE_REG(ES7210_MIC4_POWER_REG4A, 0x08);
+    /* Set ADC sample rate to 48kHz */
+    ESP_RETURN_ON_ERROR(es7210_set_i2s_sample_rate(handle, codec_conf->sample_rate_hz, codec_conf->mclk_ratio),
+                        TAG, "error while setting sample rate");
+    /* Power down DLL */
+    ES7210_WRITE_REG(ES7210_POWER_DOWN_REG06, 0x04);
+    /* Power on MIC1-4 bias & ADC1-4 & PGA1-4 Power */
+    ES7210_WRITE_REG(ES7210_MIC12_POWER_REG4B, 0x0F);
+    ES7210_WRITE_REG(ES7210_MIC34_POWER_REG4C, 0x0F);
+    /* Enable device */
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0x71);
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0x41);
+
+    return ESP_OK;
+}
+
+esp_err_t es7210_config_volume(es7210_dev_handle_t handle, int8_t volume_db)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(volume_db >= -95 && volume_db <= 32, ESP_ERR_INVALID_ARG, TAG, "invalid volume range");
+
+    /*
+     * reg_val: 0x00 represents -95.5dB, 0xBF represents 0dB (default after reset),
+     * and 0xFF represents +32dB, with a 0.5dB step
+     */
+    uint8_t reg_val = 191 + volume_db * 2;
+
+    ES7210_WRITE_REG(ES7210_ADC1_DIRECT_DB_REG1B, reg_val);
+    ES7210_WRITE_REG(ES7210_ADC2_DIRECT_DB_REG1C, reg_val);
+    ES7210_WRITE_REG(ES7210_ADC3_DIRECT_DB_REG1D, reg_val);
+    ES7210_WRITE_REG(ES7210_ADC4_DIRECT_DB_REG1E, reg_val);
+
+    return ESP_OK;
+}

--- a/questionbox/tools/mic_test/src/es7210.h
+++ b/questionbox/tools/mic_test/src/es7210.h
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ES7210 driver
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "driver/i2c.h"
+
+/**
+ * @brief I2C address of the ES7210
+ *
+ * The 8-bit address format is as follows:
+ *
+ *                (Slave Address)
+ *     ┌─────────────────┷─────────────────┐
+ *  ┌─────┐─────┐─────┐─────┐─────┐─────┐─────┐─────┐
+ *  |  1  |  0  |  0  |  0  |  0  | AD1 | AD0 | R/W |
+ *  └─────┘─────┘─────┘─────┘─────┘─────┘─────┘─────┘
+ *     └────────┯────────┘           └───┯───┘
+ *           (Fixed)          (Hardware Selectable)
+ *
+ * And the 7-bit slave address is the most important data for users.
+ * For example, if the chip's AD0,AD1 are connected to GND, its 7-bit slave address is 1000000b(0x40).
+ * Then users can use `ES7210_ADDRRES_00` to init it.
+ */
+#define ES7210_ADDRRES_00 (0x40)
+#define ES7210_ADDRESS_01 (0x41)
+#define ES7210_ADDRESS_10 (0x42)
+#define ES7210_ADDRESS_11 (0x43)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Select I2S interface format for ES7210
+ */
+typedef enum {
+    ES7210_I2S_FMT_I2S   = 0x00,    /*!< normal I2S format */
+    ES7210_I2S_FMT_LJ    = 0x01,    /*!< left justify format */
+    ES7210_I2S_FMT_DSP_A = 0x03,    /*!< DSP-A format, MSB is available on 2nd SCLK rising edge after LRCK rising edge */
+    ES7210_I2S_FMT_DSP_B = 0x13     /*!< DSP-B format, MSB is available on 1st SCLK rising edge after LRCK rising edge */
+} es7210_i2s_fmt_t;
+
+/**
+ * @brief Select I2S bit width for ES7210
+ *
+ */
+typedef enum {
+    ES7210_I2S_BITS_16B = 16,       /*!< 16-bit I2S mode */
+    ES7210_I2S_BITS_18B = 18,       /*!< 18-bit I2S mode */
+    ES7210_I2S_BITS_20B = 20,       /*!< 20-bit I2S mode */
+    ES7210_I2S_BITS_24B = 24,       /*!< 24-bit I2S mode */
+    ES7210_I2S_BITS_32B = 32        /*!< 32-bit I2S mode */
+} es7210_i2s_bits_t;
+
+/**
+ * @brief Select MIC gain for ES7210
+ *
+ */
+typedef enum {
+    ES7210_MIC_GAIN_0DB  = 0,      /*!< 0dB MIC gain */
+    ES7210_MIC_GAIN_3DB  = 1,      /*!< 3dB MIC gain */
+    ES7210_MIC_GAIN_6DB  = 2,      /*!< 6dB MIC gain */
+    ES7210_MIC_GAIN_9DB  = 3,      /*!< 9dB MIC gain */
+    ES7210_MIC_GAIN_12DB = 4,      /*!< 12dB MIC gain */
+    ES7210_MIC_GAIN_15DB = 5,      /*!< 15dB MIC gain */
+    ES7210_MIC_GAIN_18DB = 6,      /*!< 18dB MIC gain */
+    ES7210_MIC_GAIN_21DB = 7,      /*!< 21dB MIC gain */
+    ES7210_MIC_GAIN_24DB = 8,      /*!< 24dB MIC gain */
+    ES7210_MIC_GAIN_27DB = 9,      /*!< 27dB MIC gain */
+    ES7210_MIC_GAIN_30DB = 10,     /*!< 30dB MIC gain */
+    ES7210_MIC_GAIN_33DB = 11,     /*!< 33dB MIC gain */
+    ES7210_MIC_GAIN_34_5DB = 12,   /*!< 34.5dB MIC gain */
+    ES7210_MIC_GAIN_36DB = 13,     /*!< 36dB MIC gain */
+    ES7210_MIC_GAIN_37_5DB = 14    /*!< 37.5dB MIC gain */
+} es7210_mic_gain_t;
+
+/**
+ * @brief Select MIC bias for ES7210
+ *
+ */
+typedef enum {
+    ES7210_MIC_BIAS_2V18 = 0x00,   /*!< 2.18V MIC bias */
+    ES7210_MIC_BIAS_2V26 = 0x10,   /*!< 2.26V MIC bias */
+    ES7210_MIC_BIAS_2V36 = 0x20,   /*!< 2.36V MIC bias */
+    ES7210_MIC_BIAS_2V45 = 0x30,   /*!< 2.45V MIC bias */
+    ES7210_MIC_BIAS_2V55 = 0x40,   /*!< 2.55V MIC bias */
+    ES7210_MIC_BIAS_2V66 = 0x50,   /*!< 2.66V MIC bias */
+    ES7210_MIC_BIAS_2V78 = 0x60,   /*!< 2.78V MIC bias */
+    ES7210_MIC_BIAS_2V87 = 0x70    /*!< 2.87V MIC bias */
+} es7210_mic_bias_t;
+
+/**
+ * @brief Type of es7210 device handle
+ *
+ */
+typedef struct es7210_dev_t *es7210_dev_handle_t;
+
+/**
+ * @brief ES7210 I2C config struct
+ *
+ */
+typedef struct {
+    i2c_port_t  i2c_port;           /*!< I2C port used to connecte ES7210 device */
+    uint8_t     i2c_addr;           /*!< I2C address of ES7210 device, can be 0x40 0x41 0x42 or 0x43 according to A0 and A1 pin */
+} es7210_i2c_config_t;
+
+/**
+ * @brief ES7210 codec config struct
+ *
+ */
+typedef struct {
+    uint32_t sample_rate_hz;        /*!< Sample rate in Hz, common values are supported */
+    uint32_t mclk_ratio;            /*!< MCLK-to-Sample-rate clock ratio, typically 256 */
+    es7210_i2s_fmt_t i2s_format;    /*!< I2S format of ES7210's output, can be any value in es7210_i2s_fmt_t */
+    es7210_i2s_bits_t bit_width;    /*!< I2S bit width of ES7210's output, can be any value in es7210_i2s_bits_t */
+    es7210_mic_bias_t mic_bias;     /*!< Bias volatge of analog MIC, please refer to your MIC's datasheet */
+    es7210_mic_gain_t mic_gain;     /*!< Gain of analog MIC, please adjust according to your MIC's sensitivity */
+    struct {
+        uint32_t tdm_enable: 1;     /*!< Choose whether to enable TDM mode */
+    } flags;
+} es7210_codec_config_t;
+
+/**
+ * @brief Create new ES7210 device handle.
+ *
+ * @param[in]  i2c_conf Config for I2C used by ES7210
+ * @param[out] handle_out New ES7210 device handle
+ * @return
+ *          - ESP_OK                  Device handle creation success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *          - ESP_ERR_NO_MEM          Memory allocation failed.
+ *
+ */
+esp_err_t es7210_new_codec(const es7210_i2c_config_t *i2c_conf, es7210_dev_handle_t *handle_out);
+
+/**
+ * @brief Delete ES7210 device handle.
+ *
+ * @param[in] handle ES7210 device handle
+ * @return
+ *          - ESP_OK                  Device handle deletion success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *
+ */
+esp_err_t es7210_del_codec(es7210_dev_handle_t handle);
+
+/**
+ * @brief Configure codec-related parameters of ES7210.
+ *
+ * @param[in] handle ES7210 device handle
+ * @param[in] codec_conf codec-related parameters of ES7210
+ * @return
+ *          - ESP_OK                  Codec config success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *          - ESP_ERR_NO_MEM          Memory allocation failed.
+ *          - ESP_FAIL                Sending command error, slave hasn't ACK the transfer.
+ *          - ESP_ERR_INVALID_STATE   I2C driver not installed or not in master mode.
+ *          - ESP_ERR_TIMEOUT         Operation timeout because the bus is busy.
+ *
+ */
+esp_err_t es7210_config_codec(es7210_dev_handle_t handle, const es7210_codec_config_t *codec_conf);
+
+/**
+ * @brief Configure volume of ES7210.
+ *
+ * @param[in] handle ES7210 device handle
+ * @param[in] volume_db Volume to be set, in dB, with a range from -95dB to +32dB.
+ * @return
+ *          - ESP_OK                  Volume config success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *          - ESP_ERR_NO_MEM          Memory allocation failed.
+ *          - ESP_FAIL                Sending command error, slave hasn't ACK the transfer.
+ *          - ESP_ERR_INVALID_STATE   I2C driver not installed or not in master mode.
+ *          - ESP_ERR_TIMEOUT         Operation timeout because the bus is busy.
+ *
+ */
+esp_err_t es7210_config_volume(es7210_dev_handle_t handle, int8_t volume_db);
+
+#ifdef __cplusplus
+}
+#endif

--- a/questionbox/tools/mic_test/src/es7210_reg.h
+++ b/questionbox/tools/mic_test/src/es7210_reg.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/*
+ *   ES7210_REGISTER NAME_REG_REGISTER ADDRESS
+ */
+#define  ES7210_RESET_REG00                 0x00        /* Reset control */
+#define  ES7210_CLOCK_OFF_REG01             0x01        /* Used to turn off the ADC clock */
+#define  ES7210_MAINCLK_REG02               0x02        /* Set ADC clock frequency division */
+#define  ES7210_MASTER_CLK_REG03            0x03        /* MCLK source $ SCLK division */
+#define  ES7210_LRCK_DIVH_REG04             0x04        /* lrck_divh */
+#define  ES7210_LRCK_DIVL_REG05             0x05        /* lrck_divl */
+#define  ES7210_POWER_DOWN_REG06            0x06        /* power down */
+#define  ES7210_OSR_REG07                   0x07
+#define  ES7210_MODE_CONFIG_REG08           0x08        /* Set master/slave & channels */
+#define  ES7210_TIME_CONTROL0_REG09         0x09        /* Set Chip intial state period*/
+#define  ES7210_TIME_CONTROL1_REG0A         0x0A        /* Set Power up state period */
+#define  ES7210_SDP_INTERFACE1_REG11        0x11        /* Set sample & fmt */
+#define  ES7210_SDP_INTERFACE2_REG12        0x12        /* Pins state */
+
+#define  ES7210_ADC_AUTOMUTE_REG13          0x13        /* Set mute */
+#define  ES7210_ADC34_MUTERANGE_REG14       0x14        /* Set mute range */
+#define  ES7210_ALC_SEL_REG16               0x16        /* Set ALC mode */
+#define  ES7210_ADC1_DIRECT_DB_REG1B        0x1B
+#define  ES7210_ADC2_DIRECT_DB_REG1C        0x1C
+#define  ES7210_ADC3_DIRECT_DB_REG1D        0x1D
+#define  ES7210_ADC4_DIRECT_DB_REG1E        0x1E        /* ADC direct dB when ALC close, ALC max gain when ALC open */
+#define  ES7210_ADC34_HPF2_REG20            0x20        /* HPF */
+#define  ES7210_ADC34_HPF1_REG21            0x21
+#define  ES7210_ADC12_HPF2_REG22            0x22
+#define  ES7210_ADC12_HPF1_REG23            0x23
+#define  ES7210_ANALOG_REG40                0x40        /* ANALOG Power */
+
+#define  ES7210_MIC12_BIAS_REG41            0x41
+#define  ES7210_MIC34_BIAS_REG42            0x42
+#define  ES7210_MIC1_GAIN_REG43             0x43
+#define  ES7210_MIC2_GAIN_REG44             0x44
+#define  ES7210_MIC3_GAIN_REG45             0x45
+#define  ES7210_MIC4_GAIN_REG46             0x46
+#define  ES7210_MIC1_POWER_REG47            0x47
+#define  ES7210_MIC2_POWER_REG48            0x48
+#define  ES7210_MIC3_POWER_REG49            0x49
+#define  ES7210_MIC4_POWER_REG4A            0x4A
+#define  ES7210_MIC12_POWER_REG4B           0x4B        /* MICBias & ADC & PGA Power */
+#define  ES7210_MIC34_POWER_REG4C           0x4C

--- a/questionbox/tools/mic_test/src/main.cpp
+++ b/questionbox/tools/mic_test/src/main.cpp
@@ -1,70 +1,79 @@
 /*****************************************************************************
- * WonderBox microphone test.
+ * WonderBox microphone test — V2 board (ES7210 codec).
  *
- * Uses the SAME microphone driver Waveshare's official demo uses (ESP_I2S,
- * new I2S driver), on the board's mic pins. It records continuously and prints
- * the audio level twice a second. Talk/tap near the mic:
- *
- *   - If "mic peak" jumps to hundreds/thousands when you speak -> the mic
- *     hardware WORKS (and I'll switch WonderBox to this exact driver).
- *   - If it stays ~0 no matter how loud you are -> the mic hardware is faulty.
- *
- * Mic pins (Waveshare wiki): BCK=GPIO15, WS=GPIO2, DIN=GPIO39.
+ * The board is a V2: the mic is an ES7210 codec that must be configured over
+ * I2C, and audio uses the SHARED I2S bus (MCLK=2, BCK=48, WS=38, DIN=39).
+ * This test sets up the ES7210 exactly like Waveshare's example, then prints
+ * the mic level. Talk near the mic; if "mic peak" rises, the mic works.
  *****************************************************************************/
 #include <Arduino.h>
-#include <ESP_I2S.h>
 #include <Wire.h>
+#include "ESP_I2S.h"
+#include "es7210.h"
+
+#define I2S_MCK 2
+#define I2S_BCK 48
+#define I2S_WS  38
+#define I2S_DIN 39
+#define I2S_DOUT 47
+#define PIN_SDA 11
+#define PIN_SCL 10
 
 static I2SClass i2s;
+static es7210_dev_handle_t es7210 = NULL;
 static bool s_ok = false;
 
-// Scan the I2C bus and report which audio chips are present. This tells us the
-// board revision: V1 (PCM5101 + MEMS mic) vs V2 (ES8311 + ES7210 codecs).
 static void scanI2C() {
-  Wire.begin(11 /*SDA*/, 10 /*SCL*/);
   Serial.println("--- I2C scan ---");
-  int found = 0;
-  bool es8311 = false, es7210 = false;
   for (uint8_t a = 1; a < 0x7F; a++) {
     Wire.beginTransmission(a);
-    if (Wire.endTransmission() == 0) {
-      Serial.printf("  found 0x%02X\n", a);
-      found++;
-      if (a == 0x18) es8311 = true;                 // ES8311 codec
-      if (a == 0x40 || a == 0x41 || a == 0x42 || a == 0x43) es7210 = true; // ES7210 ADC
-    }
-  }
-  if (found == 0) Serial.println("  (no I2C devices found)");
-  if (es8311 || es7210) {
-    Serial.println(">>> This looks like a V2 board (ES8311/ES7210 codecs). The");
-    Serial.println(">>> mic/speaker need I2C codec setup - tell your assistant!");
-  } else {
-    Serial.println(">>> No audio codecs found -> looks like a V1 board (PCM5101 + MEMS mic).");
+    if (Wire.endTransmission() == 0) Serial.printf("  found 0x%02X\n", a);
   }
   Serial.println("----------------");
+}
+
+static void es7210_setup() {
+  es7210_i2c_config_t i2c_conf = {};
+  i2c_conf.i2c_addr = 0x40;
+  if (es7210_new_codec(&i2c_conf, &es7210) != ESP_OK) {
+    Serial.println("ES7210 new_codec FAILED");
+    return;
+  }
+  es7210_codec_config_t cc = {};
+  cc.i2s_format = ES7210_I2S_FMT_I2S;
+  cc.mclk_ratio = 256;
+  cc.sample_rate_hz = 16000;
+  cc.bit_width = ES7210_I2S_BITS_16B;
+  cc.mic_bias = ES7210_MIC_BIAS_2V87;
+  cc.mic_gain = ES7210_MIC_GAIN_36DB;
+  cc.flags.tdm_enable = false;
+  es7210_config_codec(es7210, &cc);
+  es7210_config_volume(es7210, 40);
+  Serial.println("ES7210 configured");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(600);
-  Serial.println("\n=== WonderBox MIC TEST (ESP_I2S, no PSRAM) ===");
-  scanI2C();
+  Serial.println("\n=== WonderBox MIC TEST (V2 / ES7210) ===");
 
-  // SDOUT = -1 (we only receive), MCLK = -1 (not needed for this mic).
-  i2s.setPins(15 /*BCK*/, 2 /*WS*/, -1 /*SDOUT*/, 39 /*DIN*/, -1 /*MCLK*/);
+  Wire.begin(PIN_SDA, PIN_SCL);
+  scanI2C();
+  es7210_setup();
+
+  i2s.setPins(I2S_BCK, I2S_WS, I2S_DOUT, I2S_DIN, I2S_MCK);   // note: MCLK included
   i2s.setTimeout(200);
   s_ok = i2s.begin(I2S_MODE_STD, 16000, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO);
-  Serial.println(s_ok ? "Mic started OK. Talk into it and watch 'mic peak'."
+  Serial.println(s_ok ? "I2S started. Talk into the mic and watch 'mic peak'."
                       : "ERROR: i2s.begin FAILED");
 }
 
 void loop() {
   if (!s_ok) {
     static uint32_t t = 0;
-    if (millis() - t > 1000) { t = millis(); Serial.println("mic begin FAILED - driver did not start"); }
+    if (millis() - t > 1000) { t = millis(); Serial.println("i2s begin FAILED"); }
     return;
   }
-
   static uint8_t buf[2048];
   int n = i2s.readBytes((char *)buf, sizeof(buf));
   if (n <= 0) return;
@@ -84,7 +93,6 @@ void loop() {
   if (millis() - last > 500) {
     last = millis();
     Serial.printf("mic peak = %5d   rms = %5u   %s\n",
-                  (int)peak, (unsigned)rms,
-                  peak > 500 ? "<-- HEARING SOUND" : "(quiet)");
+                  (int)peak, (unsigned)rms, peak > 500 ? "<-- HEARING SOUND" : "(quiet)");
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Your board is confirmed **V2** (ES8311 `0x18` + ES7210 `0x40`). The mic read zeros because the test used **V1 pins** (BCK=15/WS=2) and never turned on the ES7210 codec.

This updates the mic test to the real V2 setup, using Waveshare's own ES7210 driver:
- Configure **ES7210 over I2C** (`es7210_new_codec` + `es7210_config_codec`, mic gain 36dB).
- Use the **shared I2S bus with MCLK**: MCLK=GPIO2, BCK=GPIO48, WS=GPIO38, DIN=GPIO39.

If `mic peak` now rises when you speak, the mic hardware is good and I'll build the full V2 audio (ES7210 mic + ES8311 speaker + PA on GPIO15) into the firmware. Builds clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

