### PR TITLE
firmware: full V2 audio stack + playback/UX polish

### DIFF
--- a/questionbox/firmware/src/audio/audio_bus.c
+++ b/questionbox/firmware/src/audio/audio_bus.c
@@ -90,7 +90,9 @@ size_t AudioBus_MicRead(void *buf, size_t len)
 {
   if (!s_inited) return 0;
   size_t got = 0;
-  i2s_read(AUDIO_PORT, buf, len, &got, pdMS_TO_TICKS(100));
+  // Short wait: the main loop calls this every iteration, and a long block here
+  // would make the "tap again to stop" feel laggy. 20 ms keeps taps snappy.
+  i2s_read(AUDIO_PORT, buf, len, &got, pdMS_TO_TICKS(20));
   return got;
 }
 

--- a/questionbox/firmware/src/audio/audio_bus.c
+++ b/questionbox/firmware/src/audio/audio_bus.c
@@ -1,108 +1,96 @@
 #include "audio_bus.h"
+#include "audio_codecs.h"
 #include <stdio.h>
 #include <string.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-// Legacy I2S driver: lets us pick a dedicated controller per device AND avoids
-// the new driver's PSRAM/GDMA "user context not in internal RAM" failure.
+// Legacy I2S driver: unlike the newer ESP_I2S driver, it coexists with PSRAM
+// (the new driver's DMA object lands in PSRAM and GDMA rejects it -> "channel
+// not enabled"). The main firmware needs PSRAM for the record buffer + LVGL, so
+// we drive the shared V2 audio bus with the legacy driver.
 #include "driver/i2s.h"
 
-// Mic (I2S MEMS)  -> I2S_NUM_0 (RX)
-#define MIC_PORT I2S_NUM_0
-#define MIC_BCK  15
-#define MIC_WS   2
-#define MIC_DIN  39
-// Speaker (PCM5101 DAC) -> I2S_NUM_1 (TX)
-#define SPK_PORT I2S_NUM_1
-#define SPK_BCK  48
-#define SPK_WS   38
-#define SPK_DOUT 47
+// V2 board: the mic (ES7210) and speaker (ES8311) share ONE I2S bus.
+//   MCLK 2, BCK 48, WS 38, DOUT 47 (to speaker), DIN 39 (from mic)
+// The bus runs full-duplex on a single controller so both directions share the
+// same clocks. Record uses 16 kHz; playback switches to 24 kHz (MCLK follows at
+// 256x, matching whichever codec is active).
+#define AUDIO_PORT I2S_NUM_0
+#define PIN_MCLK   2
+#define PIN_BCK    48
+#define PIN_WS     38
+#define PIN_DOUT   47
+#define PIN_DIN    39
 
-static bool s_inited = false;
+#define MIC_RATE   16000
 
-static bool init_mic(void)
+static bool     s_inited = false;
+static uint32_t s_rate = MIC_RATE;
+
+static bool init_i2s(void)
 {
   i2s_config_t cfg = {
-    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
-    .sample_rate = 16000,
-    // MEMS mic: 24-bit data read in 32-bit slots, scaled down in mic.cpp.
-    // Single MEMS mics need ONLY_LEFT mono capture; stereo framing read zeros.
-    .bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT,
-    .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
-    .communication_format = I2S_COMM_FORMAT_STAND_I2S,
-    .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
-    .dma_buf_count = 8,
-    .dma_buf_len = 256,
-    .use_apll = false,
-    .tx_desc_auto_clear = false,
-    .fixed_mclk = 0,
-  };
-  if (i2s_driver_install(MIC_PORT, &cfg, 0, NULL) != ESP_OK) {
-    printf("[audio] mic driver_install failed\n");
-    return false;
-  }
-  i2s_pin_config_t pins = {
-    .mck_io_num = I2S_PIN_NO_CHANGE,
-    .bck_io_num = MIC_BCK,
-    .ws_io_num = MIC_WS,
-    .data_out_num = I2S_PIN_NO_CHANGE,
-    .data_in_num = MIC_DIN,
-  };
-  if (i2s_set_pin(MIC_PORT, &pins) != ESP_OK) {
-    printf("[audio] mic set_pin failed\n");
-    return false;
-  }
-  return true;
-}
-
-static bool init_spk(void)
-{
-  i2s_config_t cfg = {
-    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
-    .sample_rate = 24000,
+    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_TX),
+    .sample_rate = MIC_RATE,
     .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,   // stereo frames both ways
     .communication_format = I2S_COMM_FORMAT_STAND_I2S,
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
     .dma_buf_count = 8,
     .dma_buf_len = 256,
-    .use_apll = false,
-    .tx_desc_auto_clear = true,
+    .use_apll = true,                               // accurate MCLK for the codecs
+    .tx_desc_auto_clear = true,                     // output silence on underrun
     .fixed_mclk = 0,
+    .mclk_multiple = I2S_MCLK_MULTIPLE_256,
+    .bits_per_chan = I2S_BITS_PER_CHAN_16BIT,
   };
-  if (i2s_driver_install(SPK_PORT, &cfg, 0, NULL) != ESP_OK) {
-    printf("[audio] speaker driver_install failed\n");
+  if (i2s_driver_install(AUDIO_PORT, &cfg, 0, NULL) != ESP_OK) {
+    printf("[audio] i2s driver_install failed\n");
     return false;
   }
   i2s_pin_config_t pins = {
-    .mck_io_num = I2S_PIN_NO_CHANGE,
-    .bck_io_num = SPK_BCK,
-    .ws_io_num = SPK_WS,
-    .data_out_num = SPK_DOUT,
-    .data_in_num = I2S_PIN_NO_CHANGE,
+    .mck_io_num = PIN_MCLK,
+    .bck_io_num = PIN_BCK,
+    .ws_io_num = PIN_WS,
+    .data_out_num = PIN_DOUT,
+    .data_in_num = PIN_DIN,
   };
-  if (i2s_set_pin(SPK_PORT, &pins) != ESP_OK) {
-    printf("[audio] speaker set_pin failed\n");
+  if (i2s_set_pin(AUDIO_PORT, &pins) != ESP_OK) {
+    printf("[audio] i2s set_pin failed\n");
     return false;
   }
-  i2s_zero_dma_buffer(SPK_PORT);
+  i2s_zero_dma_buffer(AUDIO_PORT);
   return true;
 }
 
 bool AudioBus_Init(void)
 {
   if (s_inited) return true;
-  bool ok = init_mic() && init_spk();
-  s_inited = ok;
-  if (ok) printf("[audio] mic + speaker ready\n");
-  return ok;
+  // Codecs must be programmed over I2C before the bus starts clocking.
+  bool codecs_ok = AudioCodecs_Init();
+  bool i2s_ok = init_i2s();
+  s_inited = i2s_ok;               // audio can still limp along if a codec NAKs
+  if (i2s_ok) printf("[audio] shared I2S bus ready (%s codecs)\n",
+                     codecs_ok ? "with" : "WITHOUT");
+  return i2s_ok;
+}
+
+void AudioBus_SetSampleRate(uint32_t rate)
+{
+  if (!s_inited || rate == 0 || rate == s_rate) return;
+  // 16-bit, stereo framing; MCLK follows at the configured 256x multiple.
+  if (i2s_set_clk(AUDIO_PORT, rate, I2S_BITS_PER_SAMPLE_16BIT, I2S_CHANNEL_STEREO) == ESP_OK) {
+    s_rate = rate;
+  } else {
+    printf("[audio] set_clk %u failed\n", (unsigned)rate);
+  }
 }
 
 size_t AudioBus_MicRead(void *buf, size_t len)
 {
   if (!s_inited) return 0;
   size_t got = 0;
-  i2s_read(MIC_PORT, buf, len, &got, pdMS_TO_TICKS(100));
+  i2s_read(AUDIO_PORT, buf, len, &got, pdMS_TO_TICKS(100));
   return got;
 }
 
@@ -110,7 +98,7 @@ size_t AudioBus_SpeakerWrite(const void *buf, size_t len)
 {
   if (!s_inited) return 0;
   size_t wrote = 0;
-  i2s_write(SPK_PORT, buf, len, &wrote, pdMS_TO_TICKS(400));
+  i2s_write(AUDIO_PORT, buf, len, &wrote, pdMS_TO_TICKS(400));
   return wrote;
 }
 
@@ -120,6 +108,6 @@ void AudioBus_MicFlush(void)
   uint8_t tmp[1024];
   size_t got = 0;
   for (int i = 0; i < 8; i++) {
-    if (i2s_read(MIC_PORT, tmp, sizeof(tmp), &got, 0) != ESP_OK || got == 0) break;
+    if (i2s_read(AUDIO_PORT, tmp, sizeof(tmp), &got, 0) != ESP_OK || got == 0) break;
   }
 }

--- a/questionbox/firmware/src/audio/audio_bus.h
+++ b/questionbox/firmware/src/audio/audio_bus.h
@@ -1,20 +1,22 @@
 #pragma once
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Microphone and speaker each get their OWN dedicated I2S controller, set up
-// once at boot and kept enabled. This avoids (a) two drivers fighting over one
-// controller (which disabled the mic) and (b) opening/closing channels
-// repeatedly (which leaked channels until "no available channel found").
+// V2 board: the ES7210 mic and ES8311 speaker share ONE full-duplex I2S bus,
+// configured once at boot (see audio_bus.c). Audio flows 16-bit, stereo-framed.
 //
-//   mic     -> I2S_NUM_0, RX, 16 kHz stereo   (BCK 15, WS 2, DIN 39)
-//   speaker -> I2S_NUM_1, TX, 24 kHz stereo   (BCK 48, WS 38, DOUT 47)
+//   shared bus -> I2S_NUM_0, RX+TX   (MCLK 2, BCK 48, WS 38, DOUT 47, DIN 39)
+//
+// Record runs at 16 kHz; playback switches the bus to 24 kHz. Both directions
+// are 16-bit stereo frames. AudioBus_Init() also programs the codecs over I2C.
 
-bool   AudioBus_Init(void);                          // create + enable both, once
+bool   AudioBus_Init(void);                          // codecs + shared bus, once
+void   AudioBus_SetSampleRate(uint32_t rate);        // switch mic(16k)<->spk(24k)
 size_t AudioBus_MicRead(void *buf, size_t len);      // returns bytes read
 size_t AudioBus_SpeakerWrite(const void *buf, size_t len);
 void   AudioBus_MicFlush(void);                      // drop stale mic samples

--- a/questionbox/firmware/src/audio/audio_codecs.cpp
+++ b/questionbox/firmware/src/audio/audio_codecs.cpp
@@ -1,0 +1,93 @@
+/*****************************************************************************
+ * V2 board audio codec setup (ES7210 mic + ES8311 speaker).
+ *
+ * The ESP32-S3-Touch-LCD-1.85C-BOX (V2) does NOT expose a raw MEMS mic or a
+ * simple DAC. Both the microphone and the speaker are behind I2C codecs that
+ * must be programmed before any audio flows:
+ *
+ *   - ES7210 (addr 0x40): 4-channel ADC used for the mics. Configured for
+ *     16 kHz / 16-bit I2S capture with mic bias + gain (proven in mic_test).
+ *   - ES8311 (addr 0x18): mono DAC used for the speaker. Configured for
+ *     24 kHz / 16-bit I2S playback (proven in Waveshare's audio-out example).
+ *
+ * MCLK is supplied by the I2S peripheral on GPIO2 at 256x the sample rate, so
+ * both codecs are told mclk = rate * 256. The speaker amplifier is enabled by
+ * driving GPIO15 HIGH.
+ *
+ * These codecs share ONE I2S bus (see audio_bus.c). Because record (16 kHz) and
+ * playback (24 kHz) never happen at the same time, the bus clock is switched
+ * between the two rates; MCLK follows at 256x, matching each codec while it is
+ * the one in use.
+ *****************************************************************************/
+#include "audio_codecs.h"
+#include <Arduino.h>
+#include "es7210.h"
+#include "es8311.h"
+
+#define PA_ENABLE_PIN 15
+#define MIC_RATE      16000
+#define SPK_RATE      24000
+#define MCLK_MULTIPLE 256
+
+static es7210_dev_handle_t s_es7210 = NULL;
+static es8311_handle_t     s_es8311 = NULL;
+
+static bool init_mic_codec(void)
+{
+  es7210_i2c_config_t i2c_conf = {};
+  i2c_conf.i2c_addr = ES7210_ADDRRES_00;   // 0x40
+  if (es7210_new_codec(&i2c_conf, &s_es7210) != ESP_OK) {
+    Serial.println("[codec] ES7210 new_codec FAILED");
+    return false;
+  }
+  es7210_codec_config_t cc = {};
+  cc.i2s_format     = ES7210_I2S_FMT_I2S;
+  cc.mclk_ratio     = MCLK_MULTIPLE;
+  cc.sample_rate_hz = MIC_RATE;
+  cc.bit_width      = ES7210_I2S_BITS_16B;
+  cc.mic_bias       = ES7210_MIC_BIAS_2V87;
+  cc.mic_gain       = ES7210_MIC_GAIN_36DB;
+  cc.flags.tdm_enable = false;
+  if (es7210_config_codec(s_es7210, &cc) != ESP_OK) {
+    Serial.println("[codec] ES7210 config FAILED");
+    return false;
+  }
+  es7210_config_volume(s_es7210, 40);
+  Serial.println("[codec] ES7210 mic configured @16kHz");
+  return true;
+}
+
+static bool init_spk_codec(void)
+{
+  s_es8311 = es8311_create(I2C_NUM_0, ES8311_ADDRRES_0);   // 0x18; uses Wire internally
+  if (!s_es8311) {
+    Serial.println("[codec] ES8311 create FAILED");
+    return false;
+  }
+  es8311_clock_config_t clk = {};
+  clk.mclk_inverted     = false;
+  clk.sclk_inverted     = false;
+  clk.mclk_from_mclk_pin = true;
+  clk.mclk_frequency    = SPK_RATE * MCLK_MULTIPLE;   // 6.144 MHz
+  clk.sample_frequency  = SPK_RATE;
+  if (es8311_init(s_es8311, &clk, ES8311_RESOLUTION_16, ES8311_RESOLUTION_16) != ESP_OK) {
+    Serial.println("[codec] ES8311 init FAILED");
+    return false;
+  }
+  es8311_voice_volume_set(s_es8311, 80, NULL);
+  es8311_microphone_config(s_es8311, false);   // don't use ES8311's own mic
+  Serial.println("[codec] ES8311 speaker configured @24kHz");
+  return true;
+}
+
+bool AudioCodecs_Init(void)
+{
+  bool mic_ok = init_mic_codec();
+  bool spk_ok = init_spk_codec();
+
+  // Enable the speaker amplifier.
+  pinMode(PA_ENABLE_PIN, OUTPUT);
+  digitalWrite(PA_ENABLE_PIN, HIGH);
+
+  return mic_ok && spk_ok;
+}

--- a/questionbox/firmware/src/audio/audio_codecs.cpp
+++ b/questionbox/firmware/src/audio/audio_codecs.cpp
@@ -74,7 +74,7 @@ static bool init_spk_codec(void)
     Serial.println("[codec] ES8311 init FAILED");
     return false;
   }
-  es8311_voice_volume_set(s_es8311, 80, NULL);
+  es8311_voice_volume_set(s_es8311, 60, NULL);  // codec base level; app gain rides on top
   es8311_microphone_config(s_es8311, false);   // don't use ES8311's own mic
   Serial.println("[codec] ES8311 speaker configured @24kHz");
   return true;

--- a/questionbox/firmware/src/audio/audio_codecs.h
+++ b/questionbox/firmware/src/audio/audio_codecs.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Configures the V2 board's audio codecs over I2C (Arduino Wire, which the touch
+// controller already brought up). Must be called AFTER I2C_Init() and BEFORE the
+// I2S bus is installed, matching Waveshare's example order.
+//
+//   ES7210 (0x40) -> the microphone ADC   (configured for 16 kHz capture)
+//   ES8311 (0x18) -> the speaker DAC       (configured for 24 kHz playback)
+//   GPIO15        -> speaker amplifier enable (driven HIGH)
+//
+// Returns true if both codecs acknowledged their configuration.
+bool AudioCodecs_Init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/questionbox/firmware/src/audio/es7210.cpp
+++ b/questionbox/firmware/src/audio/es7210.cpp
@@ -1,0 +1,373 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <inttypes.h>
+#include "es7210.h"
+#include "es7210_reg.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "Wire.h"
+
+const static char *TAG = "ES7210";
+
+#define IS_ES7210_I2S_FMT(val) (((val)==ES7210_I2S_FMT_I2S) || ((val)==ES7210_I2S_FMT_LJ) || \
+        ((val)==ES7210_I2S_FMT_DSP_A) || ((val)==ES7210_I2S_FMT_DSP_B))
+
+#define IS_ES7210_I2S_BITS(val) (((val)==ES7210_I2S_BITS_24B) || ((val)==ES7210_I2S_BITS_20B) || \
+        ((val)==ES7210_I2S_BITS_18B) || ((val)==ES7210_I2S_BITS_16B) || ((val)==ES7210_I2S_BITS_32B))
+
+#define IS_ES7210_MIC_GAIN(val) (((val) >= ES7210_MIC_GAIN_0DB) && ((val) <= ES7210_MIC_GAIN_37_5DB))
+
+#define IS_ES7210_MIC_BIAS(val) (((val)==ES7210_MIC_BIAS_2V18) || ((val)==ES7210_MIC_BIAS_2V26) || \
+        ((val)==ES7210_MIC_BIAS_2V36) || ((val)==ES7210_MIC_BIAS_2V45) || ((val)==ES7210_MIC_BIAS_2V55) || \
+        ((val)==ES7210_MIC_BIAS_2V66) || ((val)==ES7210_MIC_BIAS_2V78) || ((val)==ES7210_MIC_BIAS_2V87))
+
+#define ES7210_WRITE_REG(reg_addr, reg_value) do { \
+    ESP_RETURN_ON_ERROR(es7210_write_reg(handle, (reg_addr), (reg_value)), \
+                        TAG, "i2c communication error while writing "#reg_addr); \
+} while(0)
+
+struct es7210_dev_t {
+    i2c_port_t  i2c_port;
+    uint8_t     i2c_addr;
+};
+
+/**
+ * @brief Clock coefficient structure
+ *
+ */
+typedef struct {
+    uint32_t mclk;            /*!< mclk frequency */
+    uint32_t lrck;            /*!< lrck */
+    uint8_t  ss_ds;           /*!< not used */
+    uint8_t  adc_div;         /*!< adcclk divider */
+    uint8_t  dll;             /*!< dll_bypass */
+    uint8_t  doubler;         /*!< doubler enable */
+    uint8_t  osr;             /*!< adc osr */
+    uint8_t  mclk_src;        /*!< select mclk  source */
+    uint32_t lrck_h;          /*!< The high 4 bits of lrck */
+    uint32_t lrck_l;          /*!< The low 8 bits of lrck */
+} coeff_div_t;
+
+/**
+ * @brief ES7210 clock coefficient lookup table
+ *
+ */
+static const coeff_div_t es7210_coeff_div[] = {
+//    mclk      lrck    ss_ds adc_div  dll  doubler osr  mclk_src  lrckh   lrckl
+    /* 8k */
+    {12288000,  8000,  0x00,  0x03,  0x01,  0x00,  0x20,  0x00,    0x06,  0x00},
+    {16384000,  8000,  0x00,  0x04,  0x01,  0x00,  0x20,  0x00,    0x08,  0x00},
+    {19200000,  8000,  0x00,  0x1e,  0x00,  0x01,  0x28,  0x00,    0x09,  0x60},
+    {4096000,   8000,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+
+    /* 11.025k */
+    {11289600,  11025,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x01,  0x00},
+
+    /* 12k */
+    {12288000,  12000,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x04,  0x00},
+    {19200000,  12000,  0x00,  0x14,  0x00,  0x01,  0x28,  0x00,    0x06,  0x40},
+
+    /* 16k */
+    {4096000,   16000,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},
+    {19200000,  16000,  0x00,  0x0a,  0x00,  0x00,  0x1e,  0x00,    0x04,  0x80},
+    {16384000,  16000,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x04,  0x00},
+    {12288000,  16000,  0x00,  0x03,  0x01,  0x01,  0x20,  0x00,    0x03,  0x00},
+
+    /* 22.05k */
+    {11289600,  22050,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+
+    /* 24k */
+    {12288000,  24000,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+    {19200000,  24000,  0x00,  0x0a,  0x00,  0x01,  0x28,  0x00,    0x03,  0x20},
+
+    /* 32k */
+    {12288000,  32000,  0x00,  0x03,  0x00,  0x00,  0x20,  0x00,    0x01,  0x80},
+    {16384000,  32000,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+    {19200000,  32000,  0x00,  0x05,  0x00,  0x00,  0x1e,  0x00,    0x02,  0x58},
+
+    /* 44.1k */
+    {11289600,  44100,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},
+
+    /* 48k */
+    {12288000,  48000,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},
+    {19200000,  48000,  0x00,  0x05,  0x00,  0x01,  0x28,  0x00,    0x01,  0x90},
+
+    /* 64k */
+    {16384000,  64000,  0x01,  0x01,  0x01,  0x00,  0x20,  0x00,    0x01,  0x00},
+    {19200000,  64000,  0x00,  0x05,  0x00,  0x01,  0x1e,  0x00,    0x01,  0x2c},
+
+    /* 88.2k */
+    {11289600,  88200,  0x01,  0x01,  0x01,  0x01,  0x20,  0x00,    0x00,  0x80},
+
+    /* 96k */
+    {12288000,  96000,  0x01,  0x01,  0x01,  0x01,  0x20,  0x00,    0x00,  0x80},
+    {19200000,  96000,  0x01,  0x05,  0x00,  0x01,  0x28,  0x00,    0x00,  0xc8},
+};
+
+/**
+ * @brief Get coefficient from coefficient table
+ *
+ * @param mclk Desired MCLK value
+ * @param lrck Desired LRCK vaule
+ * @return Coefficient struct, NULL if desired value cannot be achieved
+ */
+static const coeff_div_t *es7210_get_coeff(uint32_t mclk, uint32_t lrck)
+{
+    for (int i = 0; i < sizeof(es7210_coeff_div) / sizeof(coeff_div_t); i++) {
+        if (es7210_coeff_div[i].lrck == lrck && es7210_coeff_div[i].mclk == mclk) {
+            return &es7210_coeff_div[i];
+        }
+    }
+    return NULL;
+}
+
+
+static bool i2c_reg8_write(uint8_t dev_addr, uint8_t reg_addr, uint8_t *data, uint8_t len) {
+  uint8_t error;
+  Wire.beginTransmission(dev_addr);
+  Wire.write(reg_addr);
+  for (int i = 0; i < len; i++) {
+    Wire.write(*data++);
+  }
+  error = Wire.endTransmission(true);
+  if (error) {
+    printf("endTransmission: %u\n", error);
+    return false;
+  }
+  return true;
+}
+
+
+
+
+static esp_err_t es7210_write_reg(es7210_dev_handle_t handle, uint8_t reg_addr, uint8_t reg_val)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle");
+    if (i2c_reg8_write(handle->i2c_addr, reg_addr, &reg_val, 1))
+      return ESP_OK;
+    else
+      return ESP_FAIL;
+
+
+
+//     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle");
+//     esp_err_t ret = ESP_OK;
+
+//     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+//     ESP_GOTO_ON_FALSE(cmd, ESP_ERR_NO_MEM, err, TAG, "memory allocation for i2c cmd handle failed");
+
+//     ESP_GOTO_ON_ERROR(i2c_master_start(cmd), err, TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd, handle->i2c_addr << 1 | I2C_MASTER_WRITE, true),
+//                       err, TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd, reg_addr, true), err,
+//                       TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd, reg_val, true), err,
+//                       TAG, "error while appending i2c command");
+//     ESP_GOTO_ON_ERROR(i2c_master_stop(cmd), err, TAG, "error while appending i2c command");
+
+//     ESP_GOTO_ON_ERROR(i2c_master_cmd_begin(handle->i2c_port, cmd, pdMS_TO_TICKS(1000)),
+//                       err, TAG, "error while writing register");
+// err:
+//     if (cmd) {
+//         i2c_cmd_link_delete(cmd);
+//     }
+//     return ret;
+}
+
+static esp_err_t es7210_set_i2s_format(es7210_dev_handle_t handle, es7210_i2s_fmt_t i2s_format,
+                                       es7210_i2s_bits_t bit_width, bool tdm_enable)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(IS_ES7210_I2S_FMT(i2s_format), ESP_ERR_INVALID_ARG, TAG, "invalid i2s format argument");
+    ESP_RETURN_ON_FALSE(IS_ES7210_I2S_BITS(bit_width), ESP_ERR_INVALID_ARG, TAG, "invalid i2s bit width argument");
+
+    uint8_t reg_val = 0;
+
+    switch (bit_width) {
+    case ES7210_I2S_BITS_16B:
+        reg_val = 0x60;
+        break;
+    case ES7210_I2S_BITS_18B:
+        reg_val = 0x40;
+        break;
+    case ES7210_I2S_BITS_20B:
+        reg_val = 0x20;
+        break;
+    case ES7210_I2S_BITS_24B:
+        reg_val = 0x00;
+        break;
+    case ES7210_I2S_BITS_32B:
+        reg_val = 0x80;
+        break;
+    default:
+        abort();
+    }
+    ES7210_WRITE_REG(ES7210_SDP_INTERFACE1_REG11, i2s_format | reg_val);
+
+    const char *mode_str = NULL;
+    switch (i2s_format) {
+    case ES7210_I2S_FMT_I2S:
+        reg_val = 0x02;
+        mode_str = "standard i2s";
+        break;
+    case ES7210_I2S_FMT_LJ:
+        reg_val = 0x02;
+        mode_str = "left justify";
+        break;
+    case ES7210_I2S_FMT_DSP_A:
+        reg_val = 0x01;
+        mode_str = "DSP-A";
+        break;
+    case ES7210_I2S_FMT_DSP_B:
+        reg_val = 0x01;
+        mode_str = "DSP-B";
+        break;
+    default:
+        abort();
+    }
+
+    if (tdm_enable) { // enable 1xFS TDM
+        ES7210_WRITE_REG(ES7210_SDP_INTERFACE2_REG12, reg_val);
+    } else {
+        ES7210_WRITE_REG(ES7210_SDP_INTERFACE2_REG12, 0x00);
+    }
+
+    ESP_LOGI(TAG, "format: %s, bit width: %d, tdm mode %s", mode_str, bit_width, tdm_enable ? "enabled" : "disabled");
+    return ESP_OK;
+}
+
+static esp_err_t es7210_set_i2s_sample_rate(es7210_dev_handle_t handle, uint32_t sample_rate_hz, uint32_t mclk_ratio)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+
+    uint32_t mclk_freq_hz = sample_rate_hz * mclk_ratio;
+    const coeff_div_t *coeff_div = es7210_get_coeff(mclk_freq_hz, sample_rate_hz);
+    ESP_RETURN_ON_FALSE(coeff_div, ESP_ERR_NOT_SUPPORTED, TAG,
+                        "unable to set %"PRIu32"Hz sample rate with %"PRIu32"Hz MCLK", sample_rate_hz, mclk_freq_hz);
+    /* Set osr */
+    ES7210_WRITE_REG(ES7210_OSR_REG07, coeff_div->osr);
+    /* Set adc_div & doubler & dll */
+    ES7210_WRITE_REG(ES7210_MAINCLK_REG02, (coeff_div->adc_div) | (coeff_div->doubler << 6) | (coeff_div->dll << 7));
+    /* Set lrck */
+    ES7210_WRITE_REG(ES7210_LRCK_DIVH_REG04, coeff_div->lrck_h);
+    ES7210_WRITE_REG(ES7210_LRCK_DIVL_REG05, coeff_div->lrck_l);
+
+    ESP_LOGI(TAG, "sample rate: %"PRIu32"Hz, mclk frequency: %"PRIu32"Hz", sample_rate_hz, mclk_freq_hz);
+    return ESP_OK;
+}
+
+static esp_err_t es7210_set_mic_gain(es7210_dev_handle_t handle, es7210_mic_gain_t mic_gain)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(IS_ES7210_MIC_GAIN(mic_gain), ESP_ERR_INVALID_ARG, TAG, "invalid mic gain value");
+
+    ES7210_WRITE_REG(ES7210_MIC1_GAIN_REG43, mic_gain | 0x10);
+    ES7210_WRITE_REG(ES7210_MIC2_GAIN_REG44, mic_gain | 0x10);
+    ES7210_WRITE_REG(ES7210_MIC3_GAIN_REG45, mic_gain | 0x10);
+    ES7210_WRITE_REG(ES7210_MIC4_GAIN_REG46, mic_gain | 0x10);
+
+    return ESP_OK;
+}
+
+static esp_err_t es7210_set_mic_bias(es7210_dev_handle_t handle, es7210_mic_bias_t mic_bias)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(IS_ES7210_MIC_BIAS(mic_bias), ESP_ERR_INVALID_ARG, TAG, "invalid mic bias value");
+
+    ES7210_WRITE_REG(ES7210_MIC12_BIAS_REG41, mic_bias);
+    ES7210_WRITE_REG(ES7210_MIC34_BIAS_REG42, mic_bias);
+
+    return ESP_OK;
+}
+
+esp_err_t es7210_new_codec(const es7210_i2c_config_t *i2c_conf, es7210_dev_handle_t *handle_out)
+{
+    ESP_RETURN_ON_FALSE(i2c_conf, ESP_ERR_INVALID_ARG, TAG, "invalid device config pointer");
+    ESP_RETURN_ON_FALSE(handle_out, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+
+    struct es7210_dev_t *handle = (struct es7210_dev_t *)calloc(1, sizeof(struct es7210_dev_t));
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_NO_MEM, TAG, "memory allocation for device handler failed");
+
+    handle->i2c_port = i2c_conf->i2c_port;
+    handle->i2c_addr = i2c_conf->i2c_addr;
+
+    *handle_out = handle;
+    return ESP_OK;
+}
+
+esp_err_t es7210_del_codec(es7210_dev_handle_t handle)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+
+    free(handle);
+
+    return ESP_OK;
+}
+
+esp_err_t es7210_config_codec(es7210_dev_handle_t handle, const es7210_codec_config_t *codec_conf)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(codec_conf, ESP_ERR_INVALID_ARG, TAG, "invalid codec config pointer");
+
+    /* Perform software reset */
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0xFF);
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0x32);
+    /* Set the initialization time when device powers up */
+    ES7210_WRITE_REG(ES7210_TIME_CONTROL0_REG09, 0x30);
+    ES7210_WRITE_REG(ES7210_TIME_CONTROL1_REG0A, 0x30);
+    /* Configure HPF for ADC1-4 */
+    ES7210_WRITE_REG(ES7210_ADC12_HPF1_REG23, 0x2A);
+    ES7210_WRITE_REG(ES7210_ADC12_HPF2_REG22, 0x0A);
+    ES7210_WRITE_REG(ES7210_ADC34_HPF1_REG21, 0x2A);
+    ES7210_WRITE_REG(ES7210_ADC34_HPF2_REG20, 0x0A);
+    /* Set bits per sample to 16, data protocal to I2S, enable 1xFS TDM */
+    ESP_RETURN_ON_ERROR(es7210_set_i2s_format(handle, codec_conf->i2s_format, codec_conf->bit_width,
+                        codec_conf->flags.tdm_enable), TAG, "error while setting i2s format");
+    /* Configure analog power and VMID voltage */
+    ES7210_WRITE_REG(ES7210_ANALOG_REG40, 0xC3);
+    /* Set MIC14 bias to 2.87V */
+    ESP_RETURN_ON_ERROR(es7210_set_mic_bias(handle, codec_conf->mic_bias), TAG, "error while setting mic bias");
+    /* Set MIC1-4 gain to 30dB */
+    ESP_RETURN_ON_ERROR(es7210_set_mic_gain(handle, codec_conf->mic_gain), TAG, "error while setting mic gain");
+    /* Power on MIC1-4 */
+    ES7210_WRITE_REG(ES7210_MIC1_POWER_REG47, 0x08);
+    ES7210_WRITE_REG(ES7210_MIC2_POWER_REG48, 0x08);
+    ES7210_WRITE_REG(ES7210_MIC3_POWER_REG49, 0x08);
+    ES7210_WRITE_REG(ES7210_MIC4_POWER_REG4A, 0x08);
+    /* Set ADC sample rate to 48kHz */
+    ESP_RETURN_ON_ERROR(es7210_set_i2s_sample_rate(handle, codec_conf->sample_rate_hz, codec_conf->mclk_ratio),
+                        TAG, "error while setting sample rate");
+    /* Power down DLL */
+    ES7210_WRITE_REG(ES7210_POWER_DOWN_REG06, 0x04);
+    /* Power on MIC1-4 bias & ADC1-4 & PGA1-4 Power */
+    ES7210_WRITE_REG(ES7210_MIC12_POWER_REG4B, 0x0F);
+    ES7210_WRITE_REG(ES7210_MIC34_POWER_REG4C, 0x0F);
+    /* Enable device */
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0x71);
+    ES7210_WRITE_REG(ES7210_RESET_REG00, 0x41);
+
+    return ESP_OK;
+}
+
+esp_err_t es7210_config_volume(es7210_dev_handle_t handle, int8_t volume_db)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid device handle pointer");
+    ESP_RETURN_ON_FALSE(volume_db >= -95 && volume_db <= 32, ESP_ERR_INVALID_ARG, TAG, "invalid volume range");
+
+    /*
+     * reg_val: 0x00 represents -95.5dB, 0xBF represents 0dB (default after reset),
+     * and 0xFF represents +32dB, with a 0.5dB step
+     */
+    uint8_t reg_val = 191 + volume_db * 2;
+
+    ES7210_WRITE_REG(ES7210_ADC1_DIRECT_DB_REG1B, reg_val);
+    ES7210_WRITE_REG(ES7210_ADC2_DIRECT_DB_REG1C, reg_val);
+    ES7210_WRITE_REG(ES7210_ADC3_DIRECT_DB_REG1D, reg_val);
+    ES7210_WRITE_REG(ES7210_ADC4_DIRECT_DB_REG1E, reg_val);
+
+    return ESP_OK;
+}

--- a/questionbox/firmware/src/audio/es7210.h
+++ b/questionbox/firmware/src/audio/es7210.h
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ES7210 driver
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "driver/i2c.h"
+
+/**
+ * @brief I2C address of the ES7210
+ *
+ * The 8-bit address format is as follows:
+ *
+ *                (Slave Address)
+ *     ┌─────────────────┷─────────────────┐
+ *  ┌─────┐─────┐─────┐─────┐─────┐─────┐─────┐─────┐
+ *  |  1  |  0  |  0  |  0  |  0  | AD1 | AD0 | R/W |
+ *  └─────┘─────┘─────┘─────┘─────┘─────┘─────┘─────┘
+ *     └────────┯────────┘           └───┯───┘
+ *           (Fixed)          (Hardware Selectable)
+ *
+ * And the 7-bit slave address is the most important data for users.
+ * For example, if the chip's AD0,AD1 are connected to GND, its 7-bit slave address is 1000000b(0x40).
+ * Then users can use `ES7210_ADDRRES_00` to init it.
+ */
+#define ES7210_ADDRRES_00 (0x40)
+#define ES7210_ADDRESS_01 (0x41)
+#define ES7210_ADDRESS_10 (0x42)
+#define ES7210_ADDRESS_11 (0x43)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Select I2S interface format for ES7210
+ */
+typedef enum {
+    ES7210_I2S_FMT_I2S   = 0x00,    /*!< normal I2S format */
+    ES7210_I2S_FMT_LJ    = 0x01,    /*!< left justify format */
+    ES7210_I2S_FMT_DSP_A = 0x03,    /*!< DSP-A format, MSB is available on 2nd SCLK rising edge after LRCK rising edge */
+    ES7210_I2S_FMT_DSP_B = 0x13     /*!< DSP-B format, MSB is available on 1st SCLK rising edge after LRCK rising edge */
+} es7210_i2s_fmt_t;
+
+/**
+ * @brief Select I2S bit width for ES7210
+ *
+ */
+typedef enum {
+    ES7210_I2S_BITS_16B = 16,       /*!< 16-bit I2S mode */
+    ES7210_I2S_BITS_18B = 18,       /*!< 18-bit I2S mode */
+    ES7210_I2S_BITS_20B = 20,       /*!< 20-bit I2S mode */
+    ES7210_I2S_BITS_24B = 24,       /*!< 24-bit I2S mode */
+    ES7210_I2S_BITS_32B = 32        /*!< 32-bit I2S mode */
+} es7210_i2s_bits_t;
+
+/**
+ * @brief Select MIC gain for ES7210
+ *
+ */
+typedef enum {
+    ES7210_MIC_GAIN_0DB  = 0,      /*!< 0dB MIC gain */
+    ES7210_MIC_GAIN_3DB  = 1,      /*!< 3dB MIC gain */
+    ES7210_MIC_GAIN_6DB  = 2,      /*!< 6dB MIC gain */
+    ES7210_MIC_GAIN_9DB  = 3,      /*!< 9dB MIC gain */
+    ES7210_MIC_GAIN_12DB = 4,      /*!< 12dB MIC gain */
+    ES7210_MIC_GAIN_15DB = 5,      /*!< 15dB MIC gain */
+    ES7210_MIC_GAIN_18DB = 6,      /*!< 18dB MIC gain */
+    ES7210_MIC_GAIN_21DB = 7,      /*!< 21dB MIC gain */
+    ES7210_MIC_GAIN_24DB = 8,      /*!< 24dB MIC gain */
+    ES7210_MIC_GAIN_27DB = 9,      /*!< 27dB MIC gain */
+    ES7210_MIC_GAIN_30DB = 10,     /*!< 30dB MIC gain */
+    ES7210_MIC_GAIN_33DB = 11,     /*!< 33dB MIC gain */
+    ES7210_MIC_GAIN_34_5DB = 12,   /*!< 34.5dB MIC gain */
+    ES7210_MIC_GAIN_36DB = 13,     /*!< 36dB MIC gain */
+    ES7210_MIC_GAIN_37_5DB = 14    /*!< 37.5dB MIC gain */
+} es7210_mic_gain_t;
+
+/**
+ * @brief Select MIC bias for ES7210
+ *
+ */
+typedef enum {
+    ES7210_MIC_BIAS_2V18 = 0x00,   /*!< 2.18V MIC bias */
+    ES7210_MIC_BIAS_2V26 = 0x10,   /*!< 2.26V MIC bias */
+    ES7210_MIC_BIAS_2V36 = 0x20,   /*!< 2.36V MIC bias */
+    ES7210_MIC_BIAS_2V45 = 0x30,   /*!< 2.45V MIC bias */
+    ES7210_MIC_BIAS_2V55 = 0x40,   /*!< 2.55V MIC bias */
+    ES7210_MIC_BIAS_2V66 = 0x50,   /*!< 2.66V MIC bias */
+    ES7210_MIC_BIAS_2V78 = 0x60,   /*!< 2.78V MIC bias */
+    ES7210_MIC_BIAS_2V87 = 0x70    /*!< 2.87V MIC bias */
+} es7210_mic_bias_t;
+
+/**
+ * @brief Type of es7210 device handle
+ *
+ */
+typedef struct es7210_dev_t *es7210_dev_handle_t;
+
+/**
+ * @brief ES7210 I2C config struct
+ *
+ */
+typedef struct {
+    i2c_port_t  i2c_port;           /*!< I2C port used to connecte ES7210 device */
+    uint8_t     i2c_addr;           /*!< I2C address of ES7210 device, can be 0x40 0x41 0x42 or 0x43 according to A0 and A1 pin */
+} es7210_i2c_config_t;
+
+/**
+ * @brief ES7210 codec config struct
+ *
+ */
+typedef struct {
+    uint32_t sample_rate_hz;        /*!< Sample rate in Hz, common values are supported */
+    uint32_t mclk_ratio;            /*!< MCLK-to-Sample-rate clock ratio, typically 256 */
+    es7210_i2s_fmt_t i2s_format;    /*!< I2S format of ES7210's output, can be any value in es7210_i2s_fmt_t */
+    es7210_i2s_bits_t bit_width;    /*!< I2S bit width of ES7210's output, can be any value in es7210_i2s_bits_t */
+    es7210_mic_bias_t mic_bias;     /*!< Bias volatge of analog MIC, please refer to your MIC's datasheet */
+    es7210_mic_gain_t mic_gain;     /*!< Gain of analog MIC, please adjust according to your MIC's sensitivity */
+    struct {
+        uint32_t tdm_enable: 1;     /*!< Choose whether to enable TDM mode */
+    } flags;
+} es7210_codec_config_t;
+
+/**
+ * @brief Create new ES7210 device handle.
+ *
+ * @param[in]  i2c_conf Config for I2C used by ES7210
+ * @param[out] handle_out New ES7210 device handle
+ * @return
+ *          - ESP_OK                  Device handle creation success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *          - ESP_ERR_NO_MEM          Memory allocation failed.
+ *
+ */
+esp_err_t es7210_new_codec(const es7210_i2c_config_t *i2c_conf, es7210_dev_handle_t *handle_out);
+
+/**
+ * @brief Delete ES7210 device handle.
+ *
+ * @param[in] handle ES7210 device handle
+ * @return
+ *          - ESP_OK                  Device handle deletion success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *
+ */
+esp_err_t es7210_del_codec(es7210_dev_handle_t handle);
+
+/**
+ * @brief Configure codec-related parameters of ES7210.
+ *
+ * @param[in] handle ES7210 device handle
+ * @param[in] codec_conf codec-related parameters of ES7210
+ * @return
+ *          - ESP_OK                  Codec config success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *          - ESP_ERR_NO_MEM          Memory allocation failed.
+ *          - ESP_FAIL                Sending command error, slave hasn't ACK the transfer.
+ *          - ESP_ERR_INVALID_STATE   I2C driver not installed or not in master mode.
+ *          - ESP_ERR_TIMEOUT         Operation timeout because the bus is busy.
+ *
+ */
+esp_err_t es7210_config_codec(es7210_dev_handle_t handle, const es7210_codec_config_t *codec_conf);
+
+/**
+ * @brief Configure volume of ES7210.
+ *
+ * @param[in] handle ES7210 device handle
+ * @param[in] volume_db Volume to be set, in dB, with a range from -95dB to +32dB.
+ * @return
+ *          - ESP_OK                  Volume config success.
+ *          - ESP_ERR_INVALID_ARG     Invalid device handle or argument.
+ *          - ESP_ERR_NO_MEM          Memory allocation failed.
+ *          - ESP_FAIL                Sending command error, slave hasn't ACK the transfer.
+ *          - ESP_ERR_INVALID_STATE   I2C driver not installed or not in master mode.
+ *          - ESP_ERR_TIMEOUT         Operation timeout because the bus is busy.
+ *
+ */
+esp_err_t es7210_config_volume(es7210_dev_handle_t handle, int8_t volume_db);
+
+#ifdef __cplusplus
+}
+#endif

--- a/questionbox/firmware/src/audio/es7210_reg.h
+++ b/questionbox/firmware/src/audio/es7210_reg.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/*
+ *   ES7210_REGISTER NAME_REG_REGISTER ADDRESS
+ */
+#define  ES7210_RESET_REG00                 0x00        /* Reset control */
+#define  ES7210_CLOCK_OFF_REG01             0x01        /* Used to turn off the ADC clock */
+#define  ES7210_MAINCLK_REG02               0x02        /* Set ADC clock frequency division */
+#define  ES7210_MASTER_CLK_REG03            0x03        /* MCLK source $ SCLK division */
+#define  ES7210_LRCK_DIVH_REG04             0x04        /* lrck_divh */
+#define  ES7210_LRCK_DIVL_REG05             0x05        /* lrck_divl */
+#define  ES7210_POWER_DOWN_REG06            0x06        /* power down */
+#define  ES7210_OSR_REG07                   0x07
+#define  ES7210_MODE_CONFIG_REG08           0x08        /* Set master/slave & channels */
+#define  ES7210_TIME_CONTROL0_REG09         0x09        /* Set Chip intial state period*/
+#define  ES7210_TIME_CONTROL1_REG0A         0x0A        /* Set Power up state period */
+#define  ES7210_SDP_INTERFACE1_REG11        0x11        /* Set sample & fmt */
+#define  ES7210_SDP_INTERFACE2_REG12        0x12        /* Pins state */
+
+#define  ES7210_ADC_AUTOMUTE_REG13          0x13        /* Set mute */
+#define  ES7210_ADC34_MUTERANGE_REG14       0x14        /* Set mute range */
+#define  ES7210_ALC_SEL_REG16               0x16        /* Set ALC mode */
+#define  ES7210_ADC1_DIRECT_DB_REG1B        0x1B
+#define  ES7210_ADC2_DIRECT_DB_REG1C        0x1C
+#define  ES7210_ADC3_DIRECT_DB_REG1D        0x1D
+#define  ES7210_ADC4_DIRECT_DB_REG1E        0x1E        /* ADC direct dB when ALC close, ALC max gain when ALC open */
+#define  ES7210_ADC34_HPF2_REG20            0x20        /* HPF */
+#define  ES7210_ADC34_HPF1_REG21            0x21
+#define  ES7210_ADC12_HPF2_REG22            0x22
+#define  ES7210_ADC12_HPF1_REG23            0x23
+#define  ES7210_ANALOG_REG40                0x40        /* ANALOG Power */
+
+#define  ES7210_MIC12_BIAS_REG41            0x41
+#define  ES7210_MIC34_BIAS_REG42            0x42
+#define  ES7210_MIC1_GAIN_REG43             0x43
+#define  ES7210_MIC2_GAIN_REG44             0x44
+#define  ES7210_MIC3_GAIN_REG45             0x45
+#define  ES7210_MIC4_GAIN_REG46             0x46
+#define  ES7210_MIC1_POWER_REG47            0x47
+#define  ES7210_MIC2_POWER_REG48            0x48
+#define  ES7210_MIC3_POWER_REG49            0x49
+#define  ES7210_MIC4_POWER_REG4A            0x4A
+#define  ES7210_MIC12_POWER_REG4B           0x4B        /* MICBias & ADC & PGA Power */
+#define  ES7210_MIC34_POWER_REG4C           0x4C

--- a/questionbox/firmware/src/audio/es8311.cpp
+++ b/questionbox/firmware/src/audio/es8311.cpp
@@ -1,0 +1,487 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include "es8311.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "esp_check.h"
+
+#include "es8311_reg.h"
+
+#include "Wire.h"
+
+typedef struct {
+    i2c_port_t port;
+    uint16_t dev_addr;
+} es8311_dev_t;
+
+/*
+ * Clock coefficient structure
+ */
+struct _coeff_div {
+    uint32_t mclk;        /* mclk frequency */
+    uint32_t rate;        /* sample rate */
+    uint8_t pre_div;      /* the pre divider with range from 1 to 8 */
+    uint8_t pre_multi;    /* the pre multiplier with 0: 1x, 1: 2x, 2: 4x, 3: 8x selection */
+    uint8_t adc_div;      /* adcclk divider */
+    uint8_t dac_div;      /* dacclk divider */
+    uint8_t fs_mode;      /* double speed or single speed, =0, ss, =1, ds */
+    uint8_t lrck_h;       /* adclrck divider and daclrck divider */
+    uint8_t lrck_l;
+    uint8_t bclk_div;     /* sclk divider */
+    uint8_t adc_osr;      /* adc osr */
+    uint8_t dac_osr;      /* dac osr */
+};
+
+/* codec hifi mclk clock divider coefficients */
+static const struct _coeff_div coeff_div[] = {
+    /*!<mclk     rate   pre_div  mult  adc_div dac_div fs_mode lrch  lrcl  bckdiv osr */
+    /* 8k */
+    {12288000, 8000, 0x06, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 8000, 0x03, 0x01, 0x03, 0x03, 0x00, 0x05, 0xff, 0x18, 0x10, 0x10},
+    {16384000, 8000, 0x08, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000, 8000, 0x04, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 8000, 0x03, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {4096000, 8000, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 8000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2048000, 8000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 8000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1024000, 8000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 11.025k */
+    {11289600, 11025, 0x04, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800, 11025, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400, 11025, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200, 11025, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 12k */
+    {12288000, 12000, 0x04, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 12000, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 12000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 12000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 16k */
+    {12288000, 16000, 0x03, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 16000, 0x03, 0x01, 0x03, 0x03, 0x00, 0x02, 0xff, 0x0c, 0x10, 0x10},
+    {16384000, 16000, 0x04, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000, 16000, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 16000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {4096000, 16000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 16000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2048000, 16000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 16000, 0x03, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1024000, 16000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 22.05k */
+    {11289600, 22050, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800, 22050, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400, 22050, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200, 22050, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {705600, 22050, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 24k */
+    {12288000, 24000, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 24000, 0x03, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 24000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 24000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 24000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 32k */
+    {12288000, 32000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 32000, 0x03, 0x02, 0x03, 0x03, 0x00, 0x02, 0xff, 0x0c, 0x10, 0x10},
+    {16384000, 32000, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000, 32000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 32000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {4096000, 32000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 32000, 0x03, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2048000, 32000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 32000, 0x03, 0x03, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+    {1024000, 32000, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 44.1k */
+    {11289600, 44100, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800, 44100, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400, 44100, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200, 44100, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 48k */
+    {12288000, 48000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 48000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 48000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 48000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 48000, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+
+    /* 64k */
+    {12288000, 64000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 64000, 0x03, 0x02, 0x03, 0x03, 0x01, 0x01, 0x7f, 0x06, 0x10, 0x10},
+    {16384000, 64000, 0x01, 0x00, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000, 64000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 64000, 0x01, 0x02, 0x03, 0x03, 0x01, 0x01, 0x7f, 0x06, 0x10, 0x10},
+    {4096000, 64000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 64000, 0x01, 0x03, 0x03, 0x03, 0x01, 0x01, 0x7f, 0x06, 0x10, 0x10},
+    {2048000, 64000, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 64000, 0x01, 0x03, 0x01, 0x01, 0x01, 0x00, 0xbf, 0x03, 0x18, 0x18},
+    {1024000, 64000, 0x01, 0x03, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+
+    /* 88.2k */
+    {11289600, 88200, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800, 88200, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400, 88200, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200, 88200, 0x01, 0x03, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+
+    /* 96k */
+    {12288000, 96000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 96000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000, 96000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000, 96000, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000, 96000, 0x01, 0x03, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+};
+
+static const char *TAG = "ES8311";
+
+
+static bool i2c_reg8_read(uint8_t dev_addr, uint8_t reg_addr, uint8_t *data, uint8_t len) {
+  uint8_t error;
+  Wire.beginTransmission(dev_addr);
+  Wire.write(reg_addr);
+  error = Wire.endTransmission(true);
+  if (error) {
+    printf("endTransmission: %u\n", error);
+    return false;
+  }
+  Wire.requestFrom(dev_addr, len);
+  for (int i = 0; i < len; i++) {
+    *data++ = Wire.read();
+  }
+  return true;
+}
+
+static bool i2c_reg8_write(uint8_t dev_addr, uint8_t reg_addr, uint8_t *data, uint8_t len) {
+  uint8_t error;
+  Wire.beginTransmission(dev_addr);
+  Wire.write(reg_addr);
+  for (int i = 0; i < len; i++) {
+    Wire.write(*data++);
+  }
+  error = Wire.endTransmission(true);
+  if (error) {
+    printf("endTransmission: %u\n", error);
+    return false;
+  }
+  return true;
+}
+
+
+static inline esp_err_t es8311_write_reg(es8311_handle_t dev, uint8_t reg_addr, uint8_t data)
+{
+    es8311_dev_t *es = (es8311_dev_t *) dev;
+    if (i2c_reg8_write(es->dev_addr, reg_addr, &data, 1))
+      return ESP_OK;
+    else
+      return ESP_FAIL;
+    // const uint8_t write_buf[2] = {reg_addr, data};
+    // return i2c_master_write_to_device(es->port, es->dev_addr, write_buf, sizeof(write_buf), pdMS_TO_TICKS(1000));
+}
+
+static inline esp_err_t es8311_read_reg(es8311_handle_t dev, uint8_t reg_addr, uint8_t *reg_value)
+{
+    es8311_dev_t *es = (es8311_dev_t *) dev;
+
+    if (i2c_reg8_read(es->dev_addr, reg_addr, reg_value, 1))
+      return ESP_OK;
+    else
+      return ESP_FAIL;
+    // return i2c_master_write_read_device(es->port, es->dev_addr, &reg_addr, 1, reg_value, 1, pdMS_TO_TICKS(1000));
+
+}
+
+/*
+* look for the coefficient in coeff_div[] table
+*/
+static int get_coeff(uint32_t mclk, uint32_t rate)
+{
+    for (int i = 0; i < (sizeof(coeff_div) / sizeof(coeff_div[0])); i++) {
+        if (coeff_div[i].rate == rate && coeff_div[i].mclk == mclk) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+esp_err_t es8311_sample_frequency_config(es8311_handle_t dev, int mclk_frequency, int sample_frequency)
+{
+    uint8_t regv;
+
+    /* Get clock coefficients from coefficient table */
+    int coeff = get_coeff(mclk_frequency, sample_frequency);
+
+    if (coeff < 0) {
+        ESP_LOGE(TAG, "Unable to configure sample rate %dHz with %dHz MCLK", sample_frequency, mclk_frequency);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const struct _coeff_div *const selected_coeff = &coeff_div[coeff];
+
+    /* register 0x02 */
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG02, &regv), TAG, "I2C read/write error");
+    regv &= 0x07;
+    regv |= (selected_coeff->pre_div - 1) << 5;
+    regv |= selected_coeff->pre_multi << 3;
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG02, regv), TAG, "I2C read/write error");
+
+    /* register 0x03 */
+    const uint8_t reg03 = (selected_coeff->fs_mode << 6) | selected_coeff->adc_osr;
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG03, reg03), TAG, "I2C read/write error");
+
+    /* register 0x04 */
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG04, selected_coeff->dac_osr), TAG, "I2C read/write error");
+
+    /* register 0x05 */
+    const uint8_t reg05 = ((selected_coeff->adc_div - 1) << 4) | (selected_coeff->dac_div - 1);
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG05, reg05), TAG, "I2C read/write error");
+
+    /* register 0x06 */
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG06, &regv), TAG, "I2C read/write error");
+    regv &= 0xE0;
+
+    if (selected_coeff->bclk_div < 19) {
+        regv |= (selected_coeff->bclk_div - 1) << 0;
+    } else {
+        regv |= (selected_coeff->bclk_div) << 0;
+    }
+
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG06, regv), TAG, "I2C read/write error");
+
+    /* register 0x07 */
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG07, &regv), TAG, "I2C read/write error");
+    regv &= 0xC0;
+    regv |= selected_coeff->lrck_h << 0;
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG07, regv), TAG, "I2C read/write error");
+
+    /* register 0x08 */
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG08, selected_coeff->lrck_l), TAG, "I2C read/write error");
+
+    return ESP_OK;
+}
+
+static esp_err_t es8311_clock_config(es8311_handle_t dev, const es8311_clock_config_t *const clk_cfg, es8311_resolution_t res)
+{
+    uint8_t reg06;
+    uint8_t reg01 = 0x3F; // Enable all clocks
+    int mclk_hz;
+
+    /* Select clock source for internal MCLK and determine its frequency */
+    if (clk_cfg->mclk_from_mclk_pin) {
+        mclk_hz = clk_cfg->mclk_frequency;
+    } else {
+        mclk_hz = clk_cfg->sample_frequency * (int)res * 2;
+        reg01 |= BIT(7); // Select BCLK (a.k.a. SCK) pin
+    }
+
+    if (clk_cfg->mclk_inverted) {
+        reg01 |= BIT(6); // Invert MCLK pin
+    }
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG01, reg01), TAG, "I2C read/write error");
+
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_CLK_MANAGER_REG06, &reg06), TAG, "I2C read/write error");
+    if (clk_cfg->sclk_inverted) {
+        reg06 |= BIT(5);
+    } else {
+        reg06 &= ~BIT(5);
+    }
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_CLK_MANAGER_REG06, reg06), TAG, "I2C read/write error");
+
+    /* Configure clock dividers */
+    return es8311_sample_frequency_config(dev, mclk_hz, clk_cfg->sample_frequency);
+}
+
+static esp_err_t es8311_resolution_config(const es8311_resolution_t res, uint8_t *reg)
+{
+    switch (res) {
+    case ES8311_RESOLUTION_16:
+        *reg |= (3 << 2);
+        break;
+    case ES8311_RESOLUTION_18:
+        *reg |= (2 << 2);
+        break;
+    case ES8311_RESOLUTION_20:
+        *reg |= (1 << 2);
+        break;
+    case ES8311_RESOLUTION_24:
+        *reg |= (0 << 2);
+        break;
+    case ES8311_RESOLUTION_32:
+        *reg |= (4 << 2);
+        break;
+    default:
+        return ESP_ERR_INVALID_ARG;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t es8311_fmt_config(es8311_handle_t dev, const es8311_resolution_t res_in, const es8311_resolution_t res_out)
+{
+    uint8_t reg09 = 0; // SDP In
+    uint8_t reg0a = 0; // SDP Out
+
+    ESP_LOGI(TAG, "ES8311 in Slave mode and I2S format");
+    uint8_t reg00;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_RESET_REG00, &reg00), TAG, "I2C read/write error");
+    reg00 &= 0xBF;
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, reg00), TAG, "I2C read/write error"); // Slave serial port - default
+
+    /* Setup SDP In and Out resolution */
+    es8311_resolution_config(res_in, &reg09);
+    es8311_resolution_config(res_out, &reg0a);
+
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SDPIN_REG09, reg09), TAG, "I2C read/write error");
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SDPOUT_REG0A, reg0a), TAG, "I2C read/write error");
+
+    return ESP_OK;
+}
+
+esp_err_t es8311_microphone_config(es8311_handle_t dev, bool digital_mic)
+{
+    uint8_t reg14 = 0x1A; // enable analog MIC and max PGA gain
+
+    /* PDM digital microphone enable or disable */
+    if (digital_mic) {
+        reg14 |= BIT(6);
+    }
+    es8311_write_reg(dev, ES8311_ADC_REG17, 0xC8); // Set ADC gain @todo move this to ADC config section
+
+    return es8311_write_reg(dev, ES8311_SYSTEM_REG14, reg14);
+}
+
+esp_err_t es8311_init(es8311_handle_t dev, const es8311_clock_config_t *const clk_cfg, const es8311_resolution_t res_in, const es8311_resolution_t res_out)
+{
+    ESP_RETURN_ON_FALSE(
+        (clk_cfg->sample_frequency >= 8000) && (clk_cfg->sample_frequency <= 96000),
+        ESP_ERR_INVALID_ARG, TAG, "ES8311 init needs frequency in interval [8000; 96000] Hz"
+    );
+    if (!clk_cfg->mclk_from_mclk_pin) {
+        ESP_RETURN_ON_FALSE(res_out == res_in, ESP_ERR_INVALID_ARG, TAG, "Resolution IN/OUT must be equal if MCLK is taken from SCK pin");
+    }
+
+
+    /* Reset ES8311 to its default */
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, 0x1F), TAG, "I2C read/write error");
+    vTaskDelay(pdMS_TO_TICKS(20));
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, 0x00), TAG, "I2C read/write error");
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_RESET_REG00, 0x80), TAG, "I2C read/write error"); // Power-on command
+
+    /* Setup clock: source, polarity and clock dividers */
+    ESP_RETURN_ON_ERROR(es8311_clock_config(dev, clk_cfg, res_out), TAG, "");
+
+    /* Setup audio format (fmt): master/slave, resolution, I2S */
+    ESP_RETURN_ON_ERROR(es8311_fmt_config(dev, res_in, res_out), TAG, "");
+
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG0D, 0x01), TAG, "I2C read/write error"); // Power up analog circuitry - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG0E, 0x02), TAG, "I2C read/write error"); // Enable analog PGA, enable ADC modulator - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG12, 0x00), TAG, "I2C read/write error"); // power-up DAC - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_SYSTEM_REG13, 0x10), TAG, "I2C read/write error"); // Enable output to HP drive - NOT default
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_ADC_REG1C, 0x6A), TAG, "I2C read/write error"); // ADC Equalizer bypass, cancel DC offset in digital domain
+    ESP_RETURN_ON_ERROR(es8311_write_reg(dev, ES8311_DAC_REG37, 0x08), TAG, "I2C read/write error"); // Bypass DAC equalizer - NOT default
+
+    return ESP_OK;
+}
+
+void es8311_delete(es8311_handle_t dev)
+{
+    free(dev);
+}
+
+esp_err_t es8311_voice_volume_set(es8311_handle_t dev, int volume, int *volume_set)
+{
+    if (volume < 0) {
+        volume = 0;
+    } else if (volume > 100) {
+        volume = 100;
+    }
+
+    int reg32;
+    if (volume == 0) {
+        reg32 = 0;
+    } else {
+        reg32 = ((volume) * 256 / 100) - 1;
+    }
+
+    // provide user with real volume set
+    if (volume_set != NULL) {
+        *volume_set = volume;
+    }
+    return es8311_write_reg(dev, ES8311_DAC_REG32, reg32);
+}
+
+esp_err_t es8311_voice_volume_get(es8311_handle_t dev, int *volume)
+{
+    uint8_t reg32;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_DAC_REG32, &reg32), TAG, "I2C read/write error");
+
+    if (reg32 == 0) {
+        *volume = 0;
+    } else {
+        *volume = ((reg32 * 100) / 256) + 1;
+    }
+    return ESP_OK;
+}
+
+esp_err_t es8311_voice_mute(es8311_handle_t dev, bool mute)
+{
+    uint8_t reg31;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_DAC_REG31, &reg31), TAG, "I2C read/write error");
+
+    if (mute) {
+        reg31 |= BIT(6) | BIT(5);
+    } else {
+        reg31 &= ~(BIT(6) | BIT(5));
+    }
+
+    return es8311_write_reg(dev, ES8311_DAC_REG31, reg31);
+}
+
+esp_err_t es8311_microphone_gain_set(es8311_handle_t dev, es8311_mic_gain_t gain_db)
+{
+    return es8311_write_reg(dev, ES8311_ADC_REG16, gain_db); // ADC gain scale up
+}
+
+esp_err_t es8311_voice_fade(es8311_handle_t dev, const es8311_fade_t fade)
+{
+    uint8_t reg37;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_DAC_REG37, &reg37), TAG, "I2C read/write error");
+    reg37 &= 0x0F;
+    reg37 |= (fade << 4);
+    return es8311_write_reg(dev, ES8311_DAC_REG37, reg37);
+}
+
+esp_err_t es8311_microphone_fade(es8311_handle_t dev, const es8311_fade_t fade)
+{
+    uint8_t reg15;
+    ESP_RETURN_ON_ERROR(es8311_read_reg(dev, ES8311_ADC_REG15, &reg15), TAG, "I2C read/write error");
+    reg15 &= 0x0F;
+    reg15 |= (fade << 4);
+    return es8311_write_reg(dev, ES8311_ADC_REG15, reg15);
+}
+
+void es8311_register_dump(es8311_handle_t dev)
+{
+    for (int reg = 0; reg < 0x4A; reg++) {
+        uint8_t value;
+        ESP_ERROR_CHECK(es8311_read_reg(dev, reg, &value));
+        printf("REG:%02x: %02x", reg, value);
+    }
+}
+
+es8311_handle_t es8311_create(const i2c_port_t port, const uint16_t dev_addr)
+{
+    es8311_dev_t *sensor = (es8311_dev_t *) calloc(1, sizeof(es8311_dev_t));
+    sensor->port = port;
+    sensor->dev_addr = dev_addr;
+    return (es8311_handle_t) sensor;
+}

--- a/questionbox/firmware/src/audio/es8311.h
+++ b/questionbox/firmware/src/audio/es8311.h
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ES8311 driver
+ */
+
+#pragma once
+
+#include "esp_types.h"
+#include "esp_err.h"
+
+#include "driver/i2c.h"
+
+/* ES8311 address: CE pin low - 0x18, CE pin high - 0x19 */
+#define ES8311_ADDRRES_0 0x18u // Leaving this here for backward compatibility
+#define ES8311_ADDRESS_0 0x18u
+#define ES8311_ADDRESS_1 0x19u
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *es8311_handle_t;
+
+typedef enum {
+    ES8311_MIC_GAIN_MIN = -1,
+    ES8311_MIC_GAIN_0DB,
+    ES8311_MIC_GAIN_6DB,
+    ES8311_MIC_GAIN_12DB,
+    ES8311_MIC_GAIN_18DB,
+    ES8311_MIC_GAIN_24DB,
+    ES8311_MIC_GAIN_30DB,
+    ES8311_MIC_GAIN_36DB,
+    ES8311_MIC_GAIN_42DB,
+    ES8311_MIC_GAIN_MAX
+} es8311_mic_gain_t;
+
+typedef enum {
+    ES8311_FADE_OFF = 0,
+    ES8311_FADE_4LRCK, // 4LRCK means ramp 0.25dB/4LRCK
+    ES8311_FADE_8LRCK,
+    ES8311_FADE_16LRCK,
+    ES8311_FADE_32LRCK,
+    ES8311_FADE_64LRCK,
+    ES8311_FADE_128LRCK,
+    ES8311_FADE_256LRCK,
+    ES8311_FADE_512LRCK,
+    ES8311_FADE_1024LRCK,
+    ES8311_FADE_2048LRCK,
+    ES8311_FADE_4096LRCK,
+    ES8311_FADE_8192LRCK,
+    ES8311_FADE_16384LRCK,
+    ES8311_FADE_32768LRCK,
+    ES8311_FADE_65536LRCK
+} es8311_fade_t;
+
+typedef enum es8311_resolution_t {
+    ES8311_RESOLUTION_16 = 16,
+    ES8311_RESOLUTION_18 = 18,
+    ES8311_RESOLUTION_20 = 20,
+    ES8311_RESOLUTION_24 = 24,
+    ES8311_RESOLUTION_32 = 32
+} es8311_resolution_t;
+
+typedef struct es8311_clock_config_t {
+    bool mclk_inverted;
+    bool sclk_inverted;
+    bool mclk_from_mclk_pin; // true: from MCLK pin (pin no. 2), false: from SCLK pin (pin no. 6)
+    int  mclk_frequency;     // This parameter is ignored if MCLK is taken from SCLK pin
+    int  sample_frequency;   // in Hz
+} es8311_clock_config_t;
+
+/**
+ * @brief Initialize ES8311
+ *
+ * There are two ways of providing Master Clock (MCLK) signal to ES8311 in Slave Mode:
+ * 1. From MCLK pin:
+ *    For flexible scenarios. A clock signal from I2S master is routed to MCLK pin.
+ *    Its frequency must be defined in clk_cfg->mclk_frequency parameter.
+ * 2. From SCLK pin:
+ *    For simpler scenarios. ES8311 takes its clock from SCK pin. MCLK pin does not have to be connected.
+ *    In this case, res_in must equal res_out; clk_cfg->mclk_frequency parameter is ignored
+ *    and MCLK is calculated as MCLK = clk_cfg->sample_frequency * res_out * 2.
+ *    Not all sampling frequencies are supported in this mode.
+ *
+ * @param dev ES8311 handle
+ * @param[in] clk_cfg Clock configuration
+ * @param[in] res_in  Input serial port resolution
+ * @param[in] res_out Output serial port resolution
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG Sample frequency or resolution invalid
+ *     - Else fail
+ */
+esp_err_t es8311_init(es8311_handle_t dev, const es8311_clock_config_t *const clk_cfg, const es8311_resolution_t res_in,
+                      const es8311_resolution_t res_out);
+
+/**
+ * @brief Set output volume
+ *
+ * Volume paramter out of <0, 100> interval will be truncated.
+ *
+ * @param dev ES8311 handle
+ * @param[in] volume Set volume (0 ~ 100)
+ * @param[out] volume_set Volume that was set. Same as volume, unless volume is outside of <0, 100> interval.
+ *                        This parameter can be set to NULL, if user does not need this information.
+ *
+ * @return
+ *     - ESP_OK success
+ *     - Else fail
+ */
+esp_err_t es8311_voice_volume_set(es8311_handle_t dev, int volume, int *volume_set);
+
+/**
+ * @brief Get output volume
+ *
+ * @param dev ES8311 handle
+ * @param[out] volume get volume (0 ~ 100)
+ *
+ * @return
+ *     - ESP_OK success
+ *     - Else fail
+ */
+esp_err_t es8311_voice_volume_get(es8311_handle_t dev, int *volume);
+
+/**
+ * @brief Print out ES8311 register content
+ *
+ * @param dev ES8311 handle
+ */
+void es8311_register_dump(es8311_handle_t dev);
+
+/**
+ * @brief Mute ES8311 output
+ *
+ * @param dev ES8311 handle
+ * @param[in] enable true: mute, false: don't mute
+ * @return
+ *     - ESP_OK success
+ *     - Else fail
+ */
+esp_err_t es8311_voice_mute(es8311_handle_t dev, bool enable);
+
+/**
+ * @brief Set Microphone gain
+ *
+ * @param dev ES8311 handle
+ * @param[in] gain_db Microphone gain
+ * @return
+ *     - ESP_OK success
+ *     - Else fail
+ */
+esp_err_t es8311_microphone_gain_set(es8311_handle_t dev, es8311_mic_gain_t gain_db);
+
+/**
+ * @brief Configure microphone
+ *
+ * @param dev ES8311 handle
+ * @param[in] digital_mic Set to true for digital microphone
+ * @return
+ *     - ESP_OK success
+ *     - Else fail
+ */
+esp_err_t es8311_microphone_config(es8311_handle_t dev, bool digital_mic);
+
+/**
+ * @brief Configure sampling frequency
+ *
+ * @note This function is called by es8311_init().
+ *       Call this function explicitly only if you want to change sample frequency during runtime.
+ * @param dev ES8311 handle
+ * @param[in] mclk_frequency   MCLK frequency in [Hz] (MCLK or SCLK pin, depending on bit register01[7])
+ * @param[in] sample_frequency Required sample frequency in [Hz], e.g. 44100, 22050...
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG cannot set clock dividers for given MCLK and sampling frequency
+ *     - Else I2C read/write error
+ */
+esp_err_t es8311_sample_frequency_config(es8311_handle_t dev, int mclk_frequency, int sample_frequency);
+
+/**
+ * @brief Configure fade in/out for ADC: voice
+ *
+ * @param dev ES8311 handle
+ * @param[in] fade Fade ramp rate
+ * @return
+ *     - ESP_OK success
+ *     - Else I2C read/write error
+ */
+esp_err_t es8311_voice_fade(es8311_handle_t dev, const es8311_fade_t fade);
+
+/**
+ * @brief Configure fade in/out for DAC: microphone
+ *
+ * @param dev ES8311 handle
+ * @param[in] fade Fade ramp rate
+ * @return
+ *     - ESP_OK success
+ *     - Else I2C read/write error
+ */
+esp_err_t es8311_microphone_fade(es8311_handle_t dev, const es8311_fade_t fade);
+
+/**
+ * @brief Create ES8311 object and return its handle
+ *
+ * @param[in] port     I2C port number
+ * @param[in] dev_addr I2C device address of ES8311
+ *
+ * @return
+ *     - NULL Fail
+ *     - Others Success
+ */
+es8311_handle_t es8311_create(const i2c_port_t port, const uint16_t dev_addr);
+
+/**
+ * @brief Delete ES8311 object
+ *
+ * @param dev ES8311 handle
+ */
+void es8311_delete(es8311_handle_t dev);
+
+#ifdef __cplusplus
+}
+#endif

--- a/questionbox/firmware/src/audio/es8311_reg.h
+++ b/questionbox/firmware/src/audio/es8311_reg.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/*
+ *   ES8311_REGISTER NAME_REG_REGISTER ADDRESS
+ */
+#define ES8311_RESET_REG00              0x00  /*reset digital,csm,clock manager etc.*/
+
+/*
+ * Clock Scheme Register definition
+ */
+#define ES8311_CLK_MANAGER_REG01        0x01 /* select clk src for mclk, enable clock for codec */
+#define ES8311_CLK_MANAGER_REG02        0x02 /* clk divider and clk multiplier */
+#define ES8311_CLK_MANAGER_REG03        0x03 /* adc fsmode and osr  */
+#define ES8311_CLK_MANAGER_REG04        0x04 /* dac osr */
+#define ES8311_CLK_MANAGER_REG05        0x05 /* clk divier for adc and dac */
+#define ES8311_CLK_MANAGER_REG06        0x06 /* bclk inverter and divider */
+#define ES8311_CLK_MANAGER_REG07        0x07 /* tri-state, lrck divider */
+#define ES8311_CLK_MANAGER_REG08        0x08 /* lrck divider */
+/*
+ * SDP
+ */
+#define ES8311_SDPIN_REG09              0x09 /* dac serial digital port */
+#define ES8311_SDPOUT_REG0A             0x0A /* adc serial digital port */
+/*
+ * SYSTEM
+ */
+#define ES8311_SYSTEM_REG0B             0x0B /* system */
+#define ES8311_SYSTEM_REG0C             0x0C /* system */
+#define ES8311_SYSTEM_REG0D             0x0D /* system, power up/down */
+#define ES8311_SYSTEM_REG0E             0x0E /* system, power up/down */
+#define ES8311_SYSTEM_REG0F             0x0F /* system, low power */
+#define ES8311_SYSTEM_REG10             0x10 /* system */
+#define ES8311_SYSTEM_REG11             0x11 /* system */
+#define ES8311_SYSTEM_REG12             0x12 /* system, Enable DAC */
+#define ES8311_SYSTEM_REG13             0x13 /* system */
+#define ES8311_SYSTEM_REG14             0x14 /* system, select DMIC, select analog pga gain */
+/*
+ * ADC
+ */
+#define ES8311_ADC_REG15                0x15 /* ADC, adc ramp rate, dmic sense */
+#define ES8311_ADC_REG16                0x16 /* ADC */
+#define ES8311_ADC_REG17                0x17 /* ADC, volume */
+#define ES8311_ADC_REG18                0x18 /* ADC, alc enable and winsize */
+#define ES8311_ADC_REG19                0x19 /* ADC, alc maxlevel */
+#define ES8311_ADC_REG1A                0x1A /* ADC, alc automute */
+#define ES8311_ADC_REG1B                0x1B /* ADC, alc automute, adc hpf s1 */
+#define ES8311_ADC_REG1C                0x1C /* ADC, equalizer, hpf s2 */
+/*
+ * DAC
+ */
+#define ES8311_DAC_REG31                0x31 /* DAC, mute */
+#define ES8311_DAC_REG32                0x32 /* DAC, volume */
+#define ES8311_DAC_REG33                0x33 /* DAC, offset */
+#define ES8311_DAC_REG34                0x34 /* DAC, drc enable, drc winsize */
+#define ES8311_DAC_REG35                0x35 /* DAC, drc maxlevel, minilevel */
+#define ES8311_DAC_REG37                0x37 /* DAC, ramprate */
+/*
+ *GPIO
+ */
+#define ES8311_GPIO_REG44               0x44 /* GPIO, dac2adc for test */
+#define ES8311_GP_REG45                 0x45 /* GP CONTROL */
+/*
+ * CHIP
+ */
+#define ES8311_CHD1_REGFD               0xFD /* CHIP ID1 */
+#define ES8311_CHD2_REGFE               0xFE /* CHIP ID2 */
+#define ES8311_CHVER_REGFF              0xFF /* VERSION */
+#define ES8311_CHD1_REGFD               0xFD /* CHIP ID1 */
+
+#define ES8311_MAX_REGISTER             0xFF

--- a/questionbox/firmware/src/audio/mic.cpp
+++ b/questionbox/firmware/src/audio/mic.cpp
@@ -9,12 +9,14 @@
 #define REC_MAX_SAMPLES (REC_RATE * REC_MAX_SEC)
 #define WAV_HEADER_LEN  44
 
-static int32_t *s_cap = nullptr;     // captured mono, 32-bit (pre-normalization)
+// The ES7210 delivers 16-bit STEREO frames (two mic channels). We downmix to
+// mono and store 16-bit samples; a light normalization pass in Mic_GetWav lifts
+// the level so speech transcribes cleanly regardless of the raw mic scale.
+static int16_t *s_cap = nullptr;     // captured mono, int16
 static uint8_t *s_buf = nullptr;     // output WAV: [44-byte header | mono int16 PCM]
 static size_t   s_count = 0;
 static bool     s_recording = false;
 
-// Level metering.
 static int32_t  s_peakMono = 0;
 
 static inline int16_t clamp16(int32_t v)
@@ -46,7 +48,7 @@ static void write_wav_header(uint8_t *h, uint32_t dataLen, uint32_t rate)
 
 bool Mic_Begin()
 {
-  s_cap = (int32_t *)heap_caps_malloc(REC_MAX_SAMPLES * sizeof(int32_t), MALLOC_CAP_SPIRAM);
+  s_cap = (int16_t *)heap_caps_malloc(REC_MAX_SAMPLES * sizeof(int16_t), MALLOC_CAP_SPIRAM);
   s_buf = (uint8_t *)heap_caps_malloc(WAV_HEADER_LEN + REC_MAX_SAMPLES * 2, MALLOC_CAP_SPIRAM);
   if (!s_cap || !s_buf) {
     Serial.println("[mic] FAILED to allocate PSRAM buffers");
@@ -59,6 +61,7 @@ bool Mic_Begin()
 
 void Mic_Start()
 {
+  AudioBus_SetSampleRate(REC_RATE);   // ensure the bus is clocking the mic codec
   AudioBus_MicFlush();
   s_count = 0;
   s_peakMono = 0;
@@ -70,7 +73,7 @@ void Mic_Stop()
 {
   if (!s_recording) return;
   s_recording = false;
-  Serial.printf("[mic] stopped: %u samples %.2fs | peak=%d (32-bit ONLY_LEFT)\n",
+  Serial.printf("[mic] stopped: %u samples %.2fs | peak=%d\n",
                 (unsigned)s_count, (float)s_count / REC_RATE, (int)s_peakMono);
 }
 
@@ -78,17 +81,14 @@ bool Mic_Poll()
 {
   if (!s_recording) return false;
 
-  uint8_t tmp[2048];                       // 32-bit mono samples = 4 bytes each
+  int16_t tmp[1024];                       // 16-bit stereo samples (L,R interleaved)
   size_t got = AudioBus_MicRead(tmp, sizeof(tmp));
-  if (got >= 4) {
-    int n = got / 4;
-    int32_t *in = (int32_t *)tmp;
-    for (int i = 0; i < n && s_count < REC_MAX_SAMPLES; i++) {
-      int32_t s = in[i];
-      int32_t a = s < 0 ? -s : s;
-      if (a > s_peakMono) s_peakMono = a;
-      s_cap[s_count++] = s;
-    }
+  int total = (int)(got / sizeof(int16_t));
+  for (int i = 0; i + 1 < total && s_count < REC_MAX_SAMPLES; i += 2) {
+    int32_t mono = ((int32_t)tmp[i] + (int32_t)tmp[i + 1]) / 2;   // downmix two mics
+    int32_t a = mono < 0 ? -mono : mono;
+    if (a > s_peakMono) s_peakMono = a;
+    s_cap[s_count++] = (int16_t)mono;
   }
 
   if (s_count >= REC_MAX_SAMPLES) {

--- a/questionbox/firmware/src/audio/mic.h
+++ b/questionbox/firmware/src/audio/mic.h
@@ -2,8 +2,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Records mono 16 kHz / 16-bit audio from the board's I2S MEMS microphone into
-// a PSRAM buffer, and hands back a ready-to-POST WAV. PUSH-TO-TALK only.
+// Records mono 16 kHz / 16-bit audio from the board's ES7210 mic codec (16-bit
+// stereo frames, downmixed to mono) into a PSRAM buffer, and hands back a
+// ready-to-POST WAV. PUSH-TO-TALK only.
 
 bool Mic_Begin();
 

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -88,27 +88,65 @@ void Speaker_TestBeep()
   Serial.println("[spk] test beep played");
 }
 
-// ---- Dedicated-core playback ----
-// The answer is fed to I2S by a task pinned to core 0, completely separate from
-// the UI (which runs on the Arduino loop, core 1). That way LVGL rendering can
-// never stall the audio, which is what caused the choppiness. The task consumes
-// a PSRAM buffer that the main thread fills from the network as it plays, so
-// playback can start after a small pre-buffer instead of the whole download.
+// ---- Dual-task playback (producer + consumer) ----
+// A "producer" task downloads the answer into PSRAM as fast as the link allows,
+// and a "consumer" task plays it to I2S. BOTH run on core 0, apart from the UI
+// (Arduino loop, core 1), so neither the network nor LVGL rendering can starve
+// the audio — that combination is what fixes the choppiness. Playback starts
+// after a small pre-buffer, so it also begins quickly. The main thread only
+// pumps the UI and waits.
 static volatile bool s_playDone = true;   // consumer finished
 static volatile bool s_dlDone   = false;  // producer finished filling
-static volatile int  s_filled   = 0;      // bytes available in s_buf
-static const uint8_t *s_buf     = nullptr;
-static int16_t s_stereo[512 * 2];         // static so the task stack stays small
+static volatile int  s_filled   = 0;      // bytes downloaded so far
+static uint8_t      *s_buf      = nullptr;
+static int           s_total    = 0;      // total content length (WAV header + PCM)
+static Stream       *s_stream   = nullptr;
+static uint32_t      s_rate     = 24000;
+static void        (*s_onStart)() = nullptr;
+static int16_t s_stereo[512 * 2];         // static so the task stacks stay small
 
-static void playback_task(void *)
+// ~0.3s head start. The producer usually outruns playback, so this stays small
+// (small pre-buffer = quicker start), but it still absorbs first-packet jitter.
+#define PREBUF_BYTES (16 * 1024)
+
+static void producer_task(void *)
 {
-  int pos = 0;                            // bytes already played
+  int got = 0;
+  uint32_t stall = millis() + 6000;
+  while (got < s_total) {
+    int want = s_total - got;
+    if (want > 4096) want = 4096;
+    int n = s_stream->readBytes((char *)(s_buf + got), want);
+    if (n > 0) { got += n; s_filled = got; stall = millis() + 6000; }
+    else { vTaskDelay(1); if (millis() > stall) break; }
+  }
+  s_dlDone = true;
+  vTaskDelete(nullptr);
+}
+
+static void consumer_task(void *)
+{
+  // Wait for the 44-byte WAV header, then match the bus clock to its sample rate.
+  while (s_filled < 44 && !s_dlDone) vTaskDelay(1);
+  if (s_filled >= 44) {
+    uint32_t r = *(uint32_t *)(s_buf + 24);
+    if (r >= 8000 && r <= 48000) s_rate = r;
+  }
+  // Small pre-buffer so a first-packet hiccup can't clip the opening word.
+  int prebuf = 44 + PREBUF_BYTES;
+  if (prebuf > s_total) prebuf = s_total;
+  while (s_filled < prebuf && !s_dlDone) vTaskDelay(1);
+
+  AudioBus_SetSampleRate(s_rate);
+  if (s_onStart) s_onStart();              // start the mouth as sound starts
+
+  int pos = 44;                            // skip the WAV header
   for (;;) {
     int filled = s_filled;
     int avail = filled - pos;
     if (avail < 2) {
       if (s_dlDone && pos >= filled) break;
-      vTaskDelay(1);                       // wait for the producer to catch up
+      vTaskDelay(1);
       continue;
     }
     int nbytes = avail;
@@ -155,34 +193,34 @@ static void play_stream(Stream &s, int dataRemaining, void (*pump)())
   }
 }
 
-// How much to pre-buffer before starting playback (~0.8s at 24 kHz/16-bit mono).
-// Big enough to ride out network jitter, small enough to start quickly.
-#define PREBUF_BYTES (40 * 1024)
-
-// Fill s_buf from the stream, up to `limit` total bytes. Returns bytes now held.
-static int download_more(Stream &s, uint8_t *buf, int have, int limit,
-                         int dataLen, void (*pump)())
-{
-  uint32_t stall = millis() + 5000;
-  while (have < limit && have < dataLen) {
-    int want = dataLen - have;
-    if (want > 4096) want = 4096;
-    int n = s.readBytes((char *)(buf + have), want);
-    if (n > 0) {
-      have += n;
-      s_filled = have;
-      stall = millis() + 5000;
-    } else {
-      if (pump) pump();
-      delay(2);
-      if (millis() > stall) break;         // network went quiet - give up
-    }
-  }
-  return have;
-}
-
 void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onAudioStart)())
 {
+  // Preferred path: download + play on two core-0 tasks (see above) while the UI
+  // keeps rendering on core 1. Needs a known content length to size the buffer.
+  if (contentLen > 44 && contentLen <= MAX_BUFFERED_BYTES) {
+    uint8_t *buf = (uint8_t *)heap_caps_malloc(contentLen, MALLOC_CAP_SPIRAM);
+    if (buf) {
+      s_buf = buf;
+      s_total = contentLen;
+      s_stream = &s;
+      s_filled = 0;
+      s_dlDone = false;
+      s_playDone = false;
+      s_rate = 24000;
+      s_onStart = onAudioStart;
+      // Consumer runs at a slightly higher priority so feeding I2S always wins.
+      xTaskCreatePinnedToCore(producer_task, "spkdl",  4096, nullptr, 5, nullptr, 0);
+      xTaskCreatePinnedToCore(consumer_task, "spkplay", 3072, nullptr, 6, nullptr, 0);
+      while (!s_playDone) { if (pump) pump(); delay(5); }
+      heap_caps_free(buf);
+      s_buf = nullptr;
+      Serial.printf("[spk] played %d bytes (dual-task)\n", s_filled);
+      return;
+    }
+    Serial.println("[spk] PSRAM buffer alloc failed - streaming instead");
+  }
+
+  // Fallback: read the header then stream synchronously (unknown length, etc.).
   uint8_t header[44];
   if (read_exact(s, header, 44, pump) < 44) {
     Serial.println("[spk] short WAV header");
@@ -192,42 +230,8 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onA
     Serial.println("[spk] not a WAV stream");
     return;
   }
-
   uint32_t wavRate = *(uint32_t *)(header + 24);
   int dataLen = (contentLen > 44) ? (contentLen - 44) : -1;
-
-  // Preferred path: pre-buffer a little, then play on a dedicated core while the
-  // rest downloads in parallel. Smooth (UI can't starve audio) AND quick to start.
-  if (dataLen > 0 && dataLen <= MAX_BUFFERED_BYTES) {
-    uint8_t *buf = (uint8_t *)heap_caps_malloc(dataLen, MALLOC_CAP_SPIRAM);
-    if (buf) {
-      s_buf = buf;
-      s_filled = 0;
-      s_dlDone = false;
-      s_playDone = false;
-
-      int prebuf = PREBUF_BYTES < dataLen ? PREBUF_BYTES : dataLen;
-      int have = download_more(s, buf, 0, prebuf, dataLen, pump);
-
-      if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
-      if (onAudioStart) onAudioStart();     // mouth starts as sound starts
-      xTaskCreatePinnedToCore(playback_task, "spkplay", 3072, nullptr, 6, nullptr, 0);
-
-      // Keep filling the buffer (pumping the UI) until the whole answer is in.
-      have = download_more(s, buf, have, dataLen, dataLen, pump);
-      s_filled = have;
-      s_dlDone = true;
-
-      while (!s_playDone) { if (pump) pump(); delay(5); }
-      heap_caps_free(buf);
-      s_buf = nullptr;
-      Serial.printf("[spk] played %d bytes (prebuffered, dedicated core)\n", have);
-      return;
-    }
-    Serial.println("[spk] PSRAM buffer alloc failed - streaming instead");
-  }
-
-  // Fallback: stream directly (synchronous).
   if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
   if (onAudioStart) onAudioStart();
   play_stream(s, (dataLen > 0) ? dataLen : INT32_MAX, pump);

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -88,28 +88,46 @@ void Speaker_TestBeep()
   Serial.println("[spk] test beep played");
 }
 
-// Play mono 16-bit PCM already resident in RAM. Because the data is local, the
-// I2S DMA never starves on the network -> smooth, gap-free playback. The UI is
-// pumped between chunks (DMA holds enough cushion to cover a render).
-static void play_pcm_ram(const uint8_t *data, int bytes, void (*pump)())
+// ---- Dedicated-core playback ----
+// The answer is fed to I2S by a task pinned to core 0, completely separate from
+// the UI (which runs on the Arduino loop, core 1). That way LVGL rendering can
+// never stall the audio, which is what caused the choppiness. The task consumes
+// a PSRAM buffer that the main thread fills from the network as it plays, so
+// playback can start after a small pre-buffer instead of the whole download.
+static volatile bool s_playDone = true;   // consumer finished
+static volatile bool s_dlDone   = false;  // producer finished filling
+static volatile int  s_filled   = 0;      // bytes available in s_buf
+static const uint8_t *s_buf     = nullptr;
+static int16_t s_stereo[512 * 2];         // static so the task stack stays small
+
+static void playback_task(void *)
 {
-  const int CHUNK = 512;                 // mono samples per write
-  int16_t stereo[CHUNK * 2];
-  const int16_t *mono = (const int16_t *)data;
-  int total = bytes / 2;
-  int i = 0, sinceLastPump = 0;
-  while (i < total) {
-    int n = (total - i) < CHUNK ? (total - i) : CHUNK;
-    for (int k = 0; k < n; k++) {
-      int16_t v = apply_gain(mono[i + k]);
-      stereo[k * 2] = v;
-      stereo[k * 2 + 1] = v;
+  int pos = 0;                            // bytes already played
+  for (;;) {
+    int filled = s_filled;
+    int avail = filled - pos;
+    if (avail < 2) {
+      if (s_dlDone && pos >= filled) break;
+      vTaskDelay(1);                       // wait for the producer to catch up
+      continue;
     }
-    AudioBus_SpeakerWrite((uint8_t *)stereo, n * 2 * sizeof(int16_t));
-    i += n;
-    sinceLastPump += n;
-    if (pump && sinceLastPump >= 1024) { pump(); sinceLastPump = 0; }
+    int nbytes = avail;
+    if (nbytes > (int)sizeof(s_stereo) / 2) nbytes = (int)sizeof(s_stereo) / 2;
+    nbytes &= ~0x1;
+    int nsamp = nbytes / 2;
+    const int16_t *mono = (const int16_t *)(s_buf + pos);
+    for (int k = 0; k < nsamp; k++) {
+      int16_t v = apply_gain(mono[k]);
+      s_stereo[k * 2] = v;
+      s_stereo[k * 2 + 1] = v;
+    }
+    AudioBus_SpeakerWrite((uint8_t *)s_stereo, nsamp * 2 * sizeof(int16_t));
+    pos += nbytes;
   }
+  delay(120);                              // let the DMA tail drain
+  AudioBus_SetSampleRate(16000);           // hand the bus back to the mic
+  s_playDone = true;
+  vTaskDelete(nullptr);
 }
 
 // Direct streaming fallback (used only if buffering isn't possible). Prone to
@@ -137,6 +155,32 @@ static void play_stream(Stream &s, int dataRemaining, void (*pump)())
   }
 }
 
+// How much to pre-buffer before starting playback (~0.8s at 24 kHz/16-bit mono).
+// Big enough to ride out network jitter, small enough to start quickly.
+#define PREBUF_BYTES (40 * 1024)
+
+// Fill s_buf from the stream, up to `limit` total bytes. Returns bytes now held.
+static int download_more(Stream &s, uint8_t *buf, int have, int limit,
+                         int dataLen, void (*pump)())
+{
+  uint32_t stall = millis() + 5000;
+  while (have < limit && have < dataLen) {
+    int want = dataLen - have;
+    if (want > 4096) want = 4096;
+    int n = s.readBytes((char *)(buf + have), want);
+    if (n > 0) {
+      have += n;
+      s_filled = have;
+      stall = millis() + 5000;
+    } else {
+      if (pump) pump();
+      delay(2);
+      if (millis() > stall) break;         // network went quiet - give up
+    }
+  }
+  return have;
+}
+
 void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onAudioStart)())
 {
   uint8_t header[44];
@@ -152,25 +196,38 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onA
   uint32_t wavRate = *(uint32_t *)(header + 24);
   int dataLen = (contentLen > 44) ? (contentLen - 44) : -1;
 
-  // Preferred path: pull the entire answer into PSRAM first (UI shows THINKING),
-  // then play it back smoothly with no network in the audio loop.
+  // Preferred path: pre-buffer a little, then play on a dedicated core while the
+  // rest downloads in parallel. Smooth (UI can't starve audio) AND quick to start.
   if (dataLen > 0 && dataLen <= MAX_BUFFERED_BYTES) {
     uint8_t *buf = (uint8_t *)heap_caps_malloc(dataLen, MALLOC_CAP_SPIRAM);
     if (buf) {
-      int got = read_exact(s, buf, dataLen, pump);
+      s_buf = buf;
+      s_filled = 0;
+      s_dlDone = false;
+      s_playDone = false;
+
+      int prebuf = PREBUF_BYTES < dataLen ? PREBUF_BYTES : dataLen;
+      int have = download_more(s, buf, 0, prebuf, dataLen, pump);
+
       if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
-      if (onAudioStart) onAudioStart();           // start the mouth when sound starts
-      play_pcm_ram(buf, got, pump);
+      if (onAudioStart) onAudioStart();     // mouth starts as sound starts
+      xTaskCreatePinnedToCore(playback_task, "spkplay", 3072, nullptr, 6, nullptr, 0);
+
+      // Keep filling the buffer (pumping the UI) until the whole answer is in.
+      have = download_more(s, buf, have, dataLen, dataLen, pump);
+      s_filled = have;
+      s_dlDone = true;
+
+      while (!s_playDone) { if (pump) pump(); delay(5); }
       heap_caps_free(buf);
-      delay(120);                                  // let the DMA tail drain
-      AudioBus_SetSampleRate(16000);               // hand the bus back to the mic
-      Serial.printf("[spk] played %d bytes (buffered)\n", got);
+      s_buf = nullptr;
+      Serial.printf("[spk] played %d bytes (prebuffered, dedicated core)\n", have);
       return;
     }
     Serial.println("[spk] PSRAM buffer alloc failed - streaming instead");
   }
 
-  // Fallback: stream directly.
+  // Fallback: stream directly (synchronous).
   if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
   if (onAudioStart) onAudioStart();
   play_stream(s, (dataLen > 0) ? dataLen : INT32_MAX, pump);

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -59,6 +59,7 @@ static int read_exact(Stream &s, uint8_t *buf, int want, void (*pump)())
 void Speaker_TestBeep()
 {
   const int rate = 24000;
+  AudioBus_SetSampleRate(rate);      // clock the speaker codec for playback
   const int total = rate / 2;        // 0.5 seconds
   int16_t buf[256 * 2];
   int done = 0;
@@ -90,6 +91,11 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
     return;
   }
 
+  // Match the bus clock to the WAV's sample rate so playback is at the right
+  // pitch/speed (the server sends 24 kHz; the mic runs at 16 kHz).
+  uint32_t wavRate = *(uint32_t *)(header + 24);
+  if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
+
   int dataRemaining = (contentLen > 44) ? (contentLen - 44) : INT32_MAX;
 
   int16_t mono[512];
@@ -115,5 +121,6 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
 
     if (pump) pump();
   }
+  AudioBus_SetSampleRate(16000);     // hand the bus back to the mic
   Serial.println("[spk] playback done");
 }

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -1,9 +1,14 @@
 #include "speaker.h"
 #include "audio_bus.h"
+#include <esp_heap_caps.h>
+#include <math.h>
 
-// Software gain applied before the samples reach the DAC. 1.0 = original level.
-// A gentle boost helps if the answer sounds quiet even with the amp turned up.
-static float s_gain = 1.6f;
+// Software gain applied before samples reach the DAC. 1.0 = original level.
+static float s_gain = 0.6f;
+
+// Largest answer we buffer whole into PSRAM before playing (gap-free). ~30s of
+// 24 kHz/16-bit mono. Anything bigger falls back to direct streaming.
+#define MAX_BUFFERED_BYTES (1500 * 1024)
 
 void Speaker_SetGain(float g)
 {
@@ -17,8 +22,10 @@ void Speaker_SetVolumePercent(int pct)
 {
   if (pct < 0) pct = 0;
   if (pct > 100) pct = 100;
-  // 0% -> silent, ~65% -> unity, 100% -> ~2.6x boost.
-  s_gain = (pct / 100.0f) * 2.6f;
+  // Perceptual (squared) curve so low settings get MUCH quieter, and a modest
+  // ceiling so even max isn't harsh. 100% -> ~1.3x, 50% -> ~0.33x, 20% -> ~0.05x.
+  float f = pct / 100.0f;
+  s_gain = f * f * 1.3f;
 }
 
 static inline int16_t apply_gain(int16_t sample)
@@ -32,8 +39,8 @@ static inline int16_t apply_gain(int16_t sample)
 
 bool Speaker_Begin()
 {
-  // The I2S bus is enabled on demand in Speaker_PlayWavStream() (shared with the
-  // mic). Nothing to do at boot.
+  // The shared I2S bus is set up by AudioBus_Init() (via Mic_Begin). Nothing to
+  // do here.
   return true;
 }
 
@@ -68,7 +75,8 @@ void Speaker_TestBeep()
     for (int i = 0; i < cnt; i++) {
       float t = (float)(done + i) / rate;
       float env = sinf(3.14159265f * (done + i) / total);   // gentle fade in/out
-      float s = sinf(2.0f * 3.14159265f * 700.0f * t) * 0.6f * env;   // louder for audibility
+      // Quiet, friendly chime (~10% of the old level) just to confirm the path.
+      float s = sinf(2.0f * 3.14159265f * 700.0f * t) * 0.06f * env;
       int16_t v = (int16_t)(s * 32767);
       buf[i * 2] = v;
       buf[i * 2 + 1] = v;
@@ -76,10 +84,60 @@ void Speaker_TestBeep()
     AudioBus_SpeakerWrite(buf, cnt * 2 * sizeof(int16_t));   // raw, ignores volume
     done += cnt;
   }
+  AudioBus_SetSampleRate(16000);
   Serial.println("[spk] test beep played");
 }
 
-void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
+// Play mono 16-bit PCM already resident in RAM. Because the data is local, the
+// I2S DMA never starves on the network -> smooth, gap-free playback. The UI is
+// pumped between chunks (DMA holds enough cushion to cover a render).
+static void play_pcm_ram(const uint8_t *data, int bytes, void (*pump)())
+{
+  const int CHUNK = 512;                 // mono samples per write
+  int16_t stereo[CHUNK * 2];
+  const int16_t *mono = (const int16_t *)data;
+  int total = bytes / 2;
+  int i = 0, sinceLastPump = 0;
+  while (i < total) {
+    int n = (total - i) < CHUNK ? (total - i) : CHUNK;
+    for (int k = 0; k < n; k++) {
+      int16_t v = apply_gain(mono[i + k]);
+      stereo[k * 2] = v;
+      stereo[k * 2 + 1] = v;
+    }
+    AudioBus_SpeakerWrite((uint8_t *)stereo, n * 2 * sizeof(int16_t));
+    i += n;
+    sinceLastPump += n;
+    if (pump && sinceLastPump >= 1024) { pump(); sinceLastPump = 0; }
+  }
+}
+
+// Direct streaming fallback (used only if buffering isn't possible). Prone to
+// network-induced choppiness, so we prefer the buffered path above.
+static void play_stream(Stream &s, int dataRemaining, void (*pump)())
+{
+  int16_t mono[512];
+  int16_t stereo[512 * 2];
+  while (dataRemaining > 0) {
+    int want = (int)sizeof(mono);
+    if (want > dataRemaining) want = dataRemaining;
+    want &= ~0x1;
+    if (want <= 0) break;
+    int got = read_exact(s, (uint8_t *)mono, want, pump);
+    if (got <= 0) break;
+    dataRemaining -= got;
+    int samples = got / 2;
+    for (int i = 0; i < samples; i++) {
+      int16_t v = apply_gain(mono[i]);
+      stereo[i * 2] = v;
+      stereo[i * 2 + 1] = v;
+    }
+    AudioBus_SpeakerWrite((uint8_t *)stereo, samples * 2 * sizeof(int16_t));
+    if (pump) pump();
+  }
+}
+
+void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onAudioStart)())
 {
   uint8_t header[44];
   if (read_exact(s, header, 44, pump) < 44) {
@@ -91,36 +149,31 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)())
     return;
   }
 
-  // Match the bus clock to the WAV's sample rate so playback is at the right
-  // pitch/speed (the server sends 24 kHz; the mic runs at 16 kHz).
   uint32_t wavRate = *(uint32_t *)(header + 24);
-  if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
+  int dataLen = (contentLen > 44) ? (contentLen - 44) : -1;
 
-  int dataRemaining = (contentLen > 44) ? (contentLen - 44) : INT32_MAX;
-
-  int16_t mono[512];
-  int16_t stereo[512 * 2];
-
-  while (dataRemaining > 0) {
-    int want = (int)sizeof(mono);
-    if (want > dataRemaining) want = dataRemaining;
-    want &= ~0x1;                       // whole 16-bit samples
-    if (want <= 0) break;
-
-    int got = read_exact(s, (uint8_t *)mono, want, pump);
-    if (got <= 0) break;
-    dataRemaining -= got;
-
-    int samples = got / 2;
-    for (int i = 0; i < samples; i++) {
-      int16_t s = apply_gain(mono[i]);
-      stereo[i * 2] = s;
-      stereo[i * 2 + 1] = s;
+  // Preferred path: pull the entire answer into PSRAM first (UI shows THINKING),
+  // then play it back smoothly with no network in the audio loop.
+  if (dataLen > 0 && dataLen <= MAX_BUFFERED_BYTES) {
+    uint8_t *buf = (uint8_t *)heap_caps_malloc(dataLen, MALLOC_CAP_SPIRAM);
+    if (buf) {
+      int got = read_exact(s, buf, dataLen, pump);
+      if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
+      if (onAudioStart) onAudioStart();           // start the mouth when sound starts
+      play_pcm_ram(buf, got, pump);
+      heap_caps_free(buf);
+      delay(120);                                  // let the DMA tail drain
+      AudioBus_SetSampleRate(16000);               // hand the bus back to the mic
+      Serial.printf("[spk] played %d bytes (buffered)\n", got);
+      return;
     }
-    AudioBus_SpeakerWrite((uint8_t *)stereo, samples * 2 * sizeof(int16_t));
-
-    if (pump) pump();
+    Serial.println("[spk] PSRAM buffer alloc failed - streaming instead");
   }
-  AudioBus_SetSampleRate(16000);     // hand the bus back to the mic
-  Serial.println("[spk] playback done");
+
+  // Fallback: stream directly.
+  if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
+  if (onAudioStart) onAudioStart();
+  play_stream(s, (dataLen > 0) ? dataLen : INT32_MAX, pump);
+  AudioBus_SetSampleRate(16000);
+  Serial.println("[spk] playback done (streamed)");
 }

--- a/questionbox/firmware/src/audio/speaker.h
+++ b/questionbox/firmware/src/audio/speaker.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <Arduino.h>
 
-// Plays answer audio out of the PCM5101 speaker over I2S.
+// Plays answer audio out of the ES8311 speaker codec over the shared I2S bus.
 //
 // Answer audio is standardized as 16-bit PCM WAV, MONO, 24 kHz (what the server
-// produces). The 44-byte WAV header is skipped; mono samples are duplicated to
-// both stereo channels for the DAC.
+// produces). The 44-byte WAV header is read to pick the playback rate; mono
+// samples are duplicated to both stereo channels for the codec.
 
 bool Speaker_Begin();
 

--- a/questionbox/firmware/src/audio/speaker.h
+++ b/questionbox/firmware/src/audio/speaker.h
@@ -9,10 +9,13 @@
 
 bool Speaker_Begin();
 
-// Streams a WAV response body to the speaker. `pump` is called repeatedly during
-// playback so the UI (LVGL + face animation) keeps running. Audio is played
-// transiently and never stored.
-void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)());
+// Plays a WAV response body on the speaker. The whole answer is pulled into
+// PSRAM first, then played gap-free (no Wi-Fi in the audio loop = smooth). `pump`
+// keeps the UI running during download + playback. `onAudioStart` (optional) is
+// called the moment audible playback begins - use it to start the mouth so the
+// animation lines up with the sound. Audio is transient and never stored.
+void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(),
+                           void (*onAudioStart)() = nullptr);
 
 // Software loudness. gain 1.0 = as-is; >1.0 boosts (clamped). Range ~0.0..4.0.
 void  Speaker_SetGain(float gain);

--- a/questionbox/firmware/src/main.cpp
+++ b/questionbox/firmware/src/main.cpp
@@ -41,7 +41,7 @@ static uint32_t g_last_activity = 0;
 static bool     g_asleep = false;
 
 // ---- Volume (software) ----
-static int      g_volume = 70;           // 0..100
+static int      g_volume = 55;           // 0..100
 static uint32_t g_last_gesture_ms = 0;
 
 // ---- BOOT button (GPIO0) as a volume control ----
@@ -105,15 +105,21 @@ static void stop_and_send()
   xTaskCreatePinnedToCore(ask_task, "ask", 16384, nullptr, 4, nullptr, 0);
 }
 
+static void set_speaking_cb() { Face_SetState(WB_SPEAKING); }
+
 static void play_answer()
 {
-  if (g_ans.isSpelling && g_ans.spellWord.length() > 0) {
-    Face_ShowSpelling(g_ans.spellWord.c_str());
-  } else {
-    Face_SetState(WB_SPEAKING);
-  }
   Stream *body = WonderClient_GetStream();
-  if (body) Speaker_PlayWavStream(*body, WonderClient_GetLength(), pump_ui);
+  int len = WonderClient_GetLength();
+  if (g_ans.isSpelling && g_ans.spellWord.length() > 0) {
+    Face_ShowSpelling(g_ans.spellWord.c_str());        // letters stay up during audio
+    if (body) Speaker_PlayWavStream(*body, len, pump_ui, nullptr);
+  } else {
+    // Stay THINKING while the answer downloads; the mouth starts talking the
+    // instant audible playback begins (set_speaking_cb).
+    if (body) Speaker_PlayWavStream(*body, len, pump_ui, set_speaking_cb);
+    else Face_SetState(WB_SPEAKING);
+  }
   WonderClient_End();
   go_idle();
 }
@@ -146,7 +152,7 @@ static void tap_event_cb(lv_event_t *e)
     wake_up();
     return;
   }
-  if (millis() - g_last_gesture_ms < 500) return;  // ignore the click that ends a swipe
+  if (millis() - g_last_gesture_ms < 300) return;  // ignore the click that ends a swipe
   handle_tap();
 }
 

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -38,10 +38,13 @@ static const int EYE_D    = 118;   // big eyes
 static const int EYE_DX   = 52;    // horizontal offset (eyes overlap a little)
 static const int EYE_DY   = -34;
 static const int PUPIL_D  = 48;
-static const int MOUTH_W  = 148;
-static const int MOUTH_DY = 82;    // mouth center offset from screen center
-static const int MOUTH_MIN = 38;
-static const int MOUTH_MAX = 108;
+static const int MOUTH_DY = 70;    // mouth center offset from screen center
+// The talking mouth grows in BOTH width and height (a small round "o" that
+// opens into a big rounded shape), matching the reference art.
+static const int MOUTH_W_MIN = 66;
+static const int MOUTH_W_MAX = 152;
+static const int MOUTH_H_MIN = 30;
+static const int MOUTH_H_MAX = 104;
 static const int EDGE_D   = 352;
 
 // ---- Objects ----
@@ -112,26 +115,26 @@ static inline void show(lv_obj_t *o, bool v)
 
 static void schedule_blink(uint32_t now) { blink_next_ms = now + 2400 + (esp_random() % 2600); }
 
-// Shape the open mouth by `open` (0 = nearly closed, 1 = wide open), keeping the
-// pink tongue filling the bottom.
+// Shape the open mouth by `open` (0 = small round mouth, 1 = wide open), keeping
+// the pink tongue nestled in the bottom.
 static void set_mouth(float open)
 {
-  if (open < 0.10f) open = 0.10f;
+  if (open < 0.08f) open = 0.08f;
   if (open > 1.0f) open = 1.0f;
-  int mh = MOUTH_MIN + (int)((MOUTH_MAX - MOUTH_MIN) * open);
-  int rad = mh / 2;
-  if (rad > 46) rad = 46;
+  int w = MOUTH_W_MIN + (int)((MOUTH_W_MAX - MOUTH_W_MIN) * open);
+  int h = MOUTH_H_MIN + (int)((MOUTH_H_MAX - MOUTH_H_MIN) * open);
+  int rad = (w < h ? w : h) / 2;         // as round as possible = oval/pill
 
-  lv_obj_set_size(mouth, MOUTH_W, mh);
+  lv_obj_set_size(mouth, w, h);
   lv_obj_set_style_radius(mouth, rad, 0);
   lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
 
-  int tgw = (int)(MOUTH_W * 0.62f);
-  int tgh = (int)(mh * 0.5f);
+  int tgw = (int)(w * 0.72f);
+  int tgh = (int)(h * 0.55f);
   if (tgh > 46) tgh = 46;
-  if (tgh < 12) tgh = 12;
+  if (tgh < 10) tgh = 10;
   lv_obj_set_size(tongue, tgw, tgh);
-  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + mh / 2 - tgh / 2 - 3);
+  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + h / 2 - tgh / 2 - 4);
 }
 
 void Face_Create(void)
@@ -152,15 +155,15 @@ void Face_Create(void)
   tongue = make_rect(scr, COL_TONGUE, true);
   set_mouth(0.6f);
 
-  // Gentle smile (still): a shallow upturned arc.
-  smile = make_arc_seg(scr, COL_INK, 96, 9, 35, 145, true);
-  lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - 40);
+  // Gentle smile (still): a small shallow upturned arc.
+  smile = make_arc_seg(scr, COL_INK, 74, 8, 40, 140, true);
+  lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - 18);
 
-  // Happy closed eyes (speaking): two upward arcs "∩ ∩".
-  eyearc_l = make_arc_seg(scr, COL_INK, 92, 12, 210, 330, true);
-  eyearc_r = make_arc_seg(scr, COL_INK, 92, 12, 210, 330, true);
-  lv_obj_align(eyearc_l, LV_ALIGN_CENTER, -EYE_DX, EYE_DY + 18);
-  lv_obj_align(eyearc_r, LV_ALIGN_CENTER,  EYE_DX, EYE_DY + 18);
+  // Happy closed eyes (speaking): two rounded upward humps "∩ ∩".
+  eyearc_l = make_arc_seg(scr, COL_INK, 96, 13, 200, 340, true);
+  eyearc_r = make_arc_seg(scr, COL_INK, 96, 13, 200, 340, true);
+  lv_obj_align(eyearc_l, LV_ALIGN_CENTER, -EYE_DX, EYE_DY + 22);
+  lv_obj_align(eyearc_r, LV_ALIGN_CENTER,  EYE_DX, EYE_DY + 22);
 
   // Big white eyes with pupils (still).
   eye_l = make_rect(scr, COL_EYE, true);

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -31,6 +31,7 @@
 #define COL_GLOW3   0x8E7BFF  // indigo
 #define COL_VOLTRK  0xE7DECB  // volume bar track
 #define COL_VOLFILL 0x4AA8FF  // volume bar fill
+#define COL_MOUTH   0x8A4A5A  // soft rose mouth interior (shows when talking)
 
 // ---- Geometry (center 180,180) ----
 static const int EYE_D    = 60;
@@ -126,9 +127,10 @@ void Face_Create(void)
   // Smile arc (bottom curve of a circle = a happy smile).
   smile = make_arc(scr, COL_INK, 96, 12);
 
-  // Talking mouth (open/close during speech).
-  talk = make_blob(scr, COL_INK, LV_OPA_COVER);
-  lv_obj_set_size(talk, 78, 26);
+  // Talking mouth: a soft rose oval that opens and closes over the smile while
+  // speaking, so the face looks like it's happily talking.
+  talk = make_blob(scr, COL_MOUTH, LV_OPA_COVER);
+  lv_obj_set_size(talk, 58, 10);
   lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY);
 
   letter_lbl = lv_label_create(scr);
@@ -171,12 +173,22 @@ WbState Face_GetState(void) { return current; }
 // Position the smile arc. `wide` = broader, happier smile.
 static void set_smile(bool wide)
 {
-  int a = wide ? 28 : 34;          // start angle
-  int b = wide ? 152 : 146;        // end angle (through 90 = bottom = smile)
+  int a = wide ? 22 : 28;          // start angle (smaller = wider, happier grin)
+  int b = wide ? 158 : 152;        // end angle (through 90 = bottom = smile)
   lv_arc_set_bg_angles(smile, a, b);
-  int size = wide ? 108 : 96;
+  int size = wide ? 112 : 100;
   lv_obj_set_size(smile, size, size);
   lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - size / 2 + 8);
+}
+
+// Open the talking mouth by `open` (0 = closed line, 1 = wide open).
+static void set_talk(float open)
+{
+  if (open < 0) open = 0;
+  if (open > 1) open = 1;
+  int h = (int)(8 + 24.0f * open);
+  lv_obj_set_size(talk, 58, h);
+  lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY + 2);
 }
 
 void Face_SetState(WbState state)
@@ -193,8 +205,8 @@ void Face_SetState(WbState state)
 
   show(eye_l, face);
   show(eye_r, face);
-  show(smile, face);                  // keep smiling in every face state (incl. speaking)
-  show(talk, false);                  // retired the awkward open mouth
+  show(smile, face);                  // keep the happy smile in every face state
+  show(talk, speak);                  // moving mouth only while speaking
   for (int i = 0; i < 3; i++) show(comets[i], glow);
   show(letter_lbl, spell);
   show(word_lbl, spell);
@@ -314,12 +326,16 @@ void Face_Tick(void)
       spin_edge(t * 75.0f, 110);             // slow, gentle
       break;
 
-    case WB_SPEAKING:
-      // Stay smiling and lively while talking: eyes look around, edge flows.
+    case WB_SPEAKING: {
+      // Happy talking: smile stays, mouth opens/closes, eyes wander, edge flows.
       update_gaze(now, true);
       place_eyes(blink_factor(now));
       spin_edge(t * 130.0f, 190);
+      // Two overlapping rates make the flapping feel like natural speech.
+      float m = 0.5f + 0.35f * sinf(t * 15.0f) + 0.15f * sinf(t * 6.3f);
+      set_talk(m);
       break;
+    }
 
     case WB_SPELLING:
       if (spell_len > 0 && now - spell_last_ms >= SPELL_STEP_MS) {

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -1,19 +1,22 @@
 /*****************************************************************************
- * The WonderBox face — clean, cute, and alive.
+ * The WonderBox face — a cute cartoon character.
  *
- * Design goals (Apple-clean + cutesy):
- *   - a happy face by default that gently blinks and LOOKS AROUND
- *   - a smooth, flowing "Siri-style" glow around the round edge while it is
- *     listening / thinking / speaking (rotating soft light, not choppy rings)
- *   - clear per-state looks:
- *       IDLE      calm smile, eyes wander, no edge glow
- *       LISTENING big smile + bright fast flowing edge
- *       THINKING  eyes glance up + slow, dim flowing edge
- *       SPEAKING  talking mouth + medium flowing edge
- *       SPELLING  one big letter at a time
+ * Design (matches the "big-eyes + open smile" cartoon reference):
+ *   - two big white eyes with bold outlines and black pupils that wander + blink
+ *   - a friendly OPEN mouth: black cavity, a white row of teeth on top, and a
+ *     pink tongue at the bottom. While speaking, the mouth opens and closes.
+ *   - a soft, flowing "Siri-style" glow around the round edge while it is
+ *     listening / thinking / speaking.
  *
- * Everything is drawn with LVGL vector primitives (arcs + rounded shapes), so
- * it stays crisp and anti-aliased. Only moving parts update each frame.
+ * Per-state looks:
+ *   IDLE      calm happy face, eyes wander + blink, mouth softly open
+ *   LISTENING big open smile + bright fast flowing edge
+ *   THINKING  eyes glance up + slow dim edge, smaller mouth
+ *   SPEAKING  mouth opens/closes like talking + medium flowing edge
+ *   SPELLING  one big letter at a time
+ *
+ * Everything is drawn with LVGL primitives so it stays crisp. Only moving parts
+ * update each frame.
  *****************************************************************************/
 #include "face.h"
 #include <Arduino.h>
@@ -21,42 +24,48 @@
 #include <string.h>
 #include <ctype.h>
 
-// ---- Warm, friendly palette ----
-#define COL_BG      0xFFF3E0
-#define COL_INK     0x3A3F58
+// ---- Palette ----
+#define COL_BG      0xFFF3E0   // warm cream
+#define COL_OUTLINE 0x2B2B33   // bold cartoon outline / pupils
+#define COL_EYE     0xFFFFFF   // eye white
+#define COL_MOUTH   0x2B2B33   // open mouth cavity
+#define COL_TEETH   0xFFFFFF   // top teeth
+#define COL_TONGUE  0xFF7EA6   // pink tongue
 #define COL_LETTER  0x2E7DE1
-// Cool, Siri-like flowing edge colors (blend as they overlap)
-#define COL_GLOW1   0x37D6D6  // teal
-#define COL_GLOW2   0x4AA8FF  // cyan-blue
-#define COL_GLOW3   0x8E7BFF  // indigo
-#define COL_VOLTRK  0xE7DECB  // volume bar track
-#define COL_VOLFILL 0x4AA8FF  // volume bar fill
-#define COL_MOUTH   0x8A4A5A  // soft rose mouth interior (shows when talking)
+// Cool, Siri-like flowing edge colors
+#define COL_GLOW1   0x37D6D6
+#define COL_GLOW2   0x4AA8FF
+#define COL_GLOW3   0x8E7BFF
+#define COL_VOLTRK  0xE7DECB
+#define COL_VOLFILL 0x4AA8FF
 
-// ---- Geometry (center 180,180) ----
-static const int EYE_D    = 60;
-static const int EYE_DX   = 60;
-static const int EYE_DY   = -30;
-static const int MOUTH_DY = 34;
+// ---- Geometry (screen 360x360, center 180,180) ----
+static const int EYE_D    = 98;    // eye diameter
+static const int EYE_DX   = 46;    // eye horizontal offset (they nearly touch)
+static const int EYE_DY   = -36;   // eye vertical offset from center
+static const int PUPIL_D  = 44;
+static const int MOUTH_W  = 150;
+static const int MOUTH_DY = 74;    // mouth center offset from screen center
+static const int MOUTH_MIN = 46;
+static const int MOUTH_MAX = 98;
 static const int EDGE_D   = 352;
 
 // ---- Objects ----
 static lv_obj_t *eye_l, *eye_r;
-static lv_obj_t *smile;        // arc smile (idle/listening/thinking)
-static lv_obj_t *talk;         // filled mouth (speaking)
-static lv_obj_t *comets[3];    // flowing edge glow
-static lv_obj_t *vol_arc;      // curved volume bar
+static lv_obj_t *pupil_l, *pupil_r;
+static lv_obj_t *mouth, *teeth, *tongue;
+static lv_obj_t *comets[3];
+static lv_obj_t *vol_arc;
 static lv_obj_t *letter_lbl, *word_lbl;
 
-static uint32_t vol_hide_ms = 0;   // when to auto-hide the volume bar
-
+static uint32_t vol_hide_ms = 0;
 static WbState current = WB_IDLE;
 
 // blink
 static uint32_t blink_next_ms = 0, blink_start_ms = 0;
 static const uint32_t BLINK_MS = 150;
 
-// gaze (look-around)
+// gaze
 static float gaze_cx = 0, gaze_cy = 0, gaze_tx = 0, gaze_ty = 0;
 static uint32_t gaze_next_ms = 0;
 
@@ -66,15 +75,20 @@ static int spell_len = 0, spell_index = 0;
 static uint32_t spell_last_ms = 0;
 static const uint32_t SPELL_STEP_MS = 800;
 
-static lv_obj_t *make_blob(lv_obj_t *parent, uint32_t color, lv_opa_t opa)
+static lv_obj_t *make_rect(lv_obj_t *parent, uint32_t fill, uint32_t outline, int border, bool circle)
 {
   lv_obj_t *o = lv_obj_create(parent);
   lv_obj_remove_style_all(o);
   lv_obj_clear_flag(o, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_clear_flag(o, LV_OBJ_FLAG_CLICKABLE);
-  lv_obj_set_style_radius(o, LV_RADIUS_CIRCLE, 0);
-  lv_obj_set_style_bg_color(o, lv_color_hex(color), 0);
-  lv_obj_set_style_bg_opa(o, opa, 0);
+  lv_obj_set_style_radius(o, circle ? LV_RADIUS_CIRCLE : 0, 0);
+  lv_obj_set_style_bg_color(o, lv_color_hex(fill), 0);
+  lv_obj_set_style_bg_opa(o, LV_OPA_COVER, 0);
+  if (border > 0) {
+    lv_obj_set_style_border_color(o, lv_color_hex(outline), 0);
+    lv_obj_set_style_border_width(o, border, 0);
+    lv_obj_set_style_border_opa(o, LV_OPA_COVER, 0);
+  }
   return o;
 }
 
@@ -91,8 +105,8 @@ static lv_obj_t *make_arc(lv_obj_t *parent, uint32_t color, int size, int width)
   lv_obj_set_style_arc_color(a, lv_color_hex(color), LV_PART_MAIN);
   lv_obj_set_style_arc_width(a, width, LV_PART_MAIN);
   lv_obj_set_style_arc_rounded(a, true, LV_PART_MAIN);
-  lv_obj_set_style_arc_width(a, 0, LV_PART_INDICATOR);          // hide indicator
-  lv_obj_set_style_bg_opa(a, LV_OPA_TRANSP, LV_PART_KNOB);      // hide knob
+  lv_obj_set_style_arc_width(a, 0, LV_PART_INDICATOR);
+  lv_obj_set_style_bg_opa(a, LV_OPA_TRANSP, LV_PART_KNOB);
   lv_obj_set_style_pad_all(a, 0, LV_PART_KNOB);
   return a;
 }
@@ -105,6 +119,29 @@ static inline void show(lv_obj_t *o, bool v)
 
 static void schedule_blink(uint32_t now) { blink_next_ms = now + 2400 + (esp_random() % 2600); }
 
+// Shape the open mouth by `open` (0 = nearly closed, 1 = wide open), keeping the
+// white teeth hugging the top and the pink tongue at the bottom.
+static void set_mouth(float open)
+{
+  if (open < 0.10f) open = 0.10f;
+  if (open > 1.0f) open = 1.0f;
+  int mh = MOUTH_MIN + (int)((MOUTH_MAX - MOUTH_MIN) * open);
+
+  lv_obj_set_size(mouth, MOUTH_W, mh);
+  lv_obj_set_style_radius(mouth, mh / 2, 0);
+  lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
+
+  int tw = MOUTH_W - 30, th = 22;
+  lv_obj_set_size(teeth, tw, th);
+  lv_obj_align(teeth, LV_ALIGN_CENTER, 0, MOUTH_DY - mh / 2 + th / 2 + 5);
+
+  int tgw = 74, tgh = (int)(mh * 0.42f);
+  if (tgh > 42) tgh = 42;
+  if (tgh < 14) tgh = 14;
+  lv_obj_set_size(tongue, tgw, tgh);
+  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + mh / 2 - tgh / 2 - 5);
+}
+
 void Face_Create(void)
 {
   lv_obj_t *scr = lv_scr_act();
@@ -112,26 +149,29 @@ void Face_Create(void)
   lv_obj_set_style_bg_color(scr, lv_color_hex(COL_BG), 0);
   lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
 
-  // Edge glow (behind everything): three cool arc segments hugging the edge.
+  // Edge glow (behind everything).
   const uint32_t glow_cols[3] = {COL_GLOW1, COL_GLOW2, COL_GLOW3};
   for (int i = 0; i < 3; i++) {
     comets[i] = make_arc(scr, glow_cols[i], EDGE_D, 10);
-    lv_arc_set_bg_angles(comets[i], 0, 110);  // fixed segment; we spin via rotation
+    lv_arc_set_bg_angles(comets[i], 0, 110);
   }
 
-  eye_l = make_blob(scr, COL_INK, LV_OPA_COVER);
-  eye_r = make_blob(scr, COL_INK, LV_OPA_COVER);
+  // Mouth group (create before eyes; eyes/pupils sit visually above).
+  mouth  = make_rect(scr, COL_MOUTH, COL_OUTLINE, 4, false);
+  teeth  = make_rect(scr, COL_TEETH, 0, 0, false);
+  lv_obj_set_style_radius(teeth, 9, 0);
+  tongue = make_rect(scr, COL_TONGUE, 0, 0, true);
+  set_mouth(0.66f);
+
+  // Big cartoon eyes: white with a bold outline, black pupils inside.
+  eye_l = make_rect(scr, COL_EYE, COL_OUTLINE, 5, true);
+  eye_r = make_rect(scr, COL_EYE, COL_OUTLINE, 5, true);
   lv_obj_set_size(eye_l, EYE_D, EYE_D);
   lv_obj_set_size(eye_r, EYE_D, EYE_D);
-
-  // Smile arc (bottom curve of a circle = a happy smile).
-  smile = make_arc(scr, COL_INK, 96, 12);
-
-  // Talking mouth: a soft rose oval that opens and closes over the smile while
-  // speaking, so the face looks like it's happily talking.
-  talk = make_blob(scr, COL_MOUTH, LV_OPA_COVER);
-  lv_obj_set_size(talk, 58, 10);
-  lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY);
+  pupil_l = make_rect(scr, COL_OUTLINE, 0, 0, true);
+  pupil_r = make_rect(scr, COL_OUTLINE, 0, 0, true);
+  lv_obj_set_size(pupil_l, PUPIL_D, PUPIL_D);
+  lv_obj_set_size(pupil_r, PUPIL_D, PUPIL_D);
 
   letter_lbl = lv_label_create(scr);
   lv_obj_set_style_text_color(letter_lbl, lv_color_hex(COL_LETTER), 0);
@@ -140,19 +180,19 @@ void Face_Create(void)
   lv_obj_align(letter_lbl, LV_ALIGN_CENTER, 0, -18);
 
   word_lbl = lv_label_create(scr);
-  lv_obj_set_style_text_color(word_lbl, lv_color_hex(COL_INK), 0);
+  lv_obj_set_style_text_color(word_lbl, lv_color_hex(COL_OUTLINE), 0);
   lv_obj_set_style_text_font(word_lbl, &lv_font_montserrat_28, 0);
   lv_label_set_text(word_lbl, "");
   lv_obj_align(word_lbl, LV_ALIGN_CENTER, 0, 70);
 
-  // Minimal curved volume bar (a rounded arc that fills as volume rises).
+  // Minimal curved volume bar.
   vol_arc = lv_arc_create(scr);
   lv_obj_remove_style_all(vol_arc);
   lv_obj_clear_flag(vol_arc, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_set_size(vol_arc, 300, 300);
   lv_obj_center(vol_arc);
   lv_arc_set_rotation(vol_arc, 0);
-  lv_arc_set_bg_angles(vol_arc, 40, 140);       // a curved bar across the bottom
+  lv_arc_set_bg_angles(vol_arc, 40, 140);
   lv_arc_set_range(vol_arc, 0, 100);
   lv_obj_set_style_arc_color(vol_arc, lv_color_hex(COL_VOLTRK), LV_PART_MAIN);
   lv_obj_set_style_arc_width(vol_arc, 12, LV_PART_MAIN);
@@ -170,27 +210,6 @@ void Face_Create(void)
 
 WbState Face_GetState(void) { return current; }
 
-// Position the smile arc. `wide` = broader, happier smile.
-static void set_smile(bool wide)
-{
-  int a = wide ? 22 : 28;          // start angle (smaller = wider, happier grin)
-  int b = wide ? 158 : 152;        // end angle (through 90 = bottom = smile)
-  lv_arc_set_bg_angles(smile, a, b);
-  int size = wide ? 112 : 100;
-  lv_obj_set_size(smile, size, size);
-  lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - size / 2 + 8);
-}
-
-// Open the talking mouth by `open` (0 = closed line, 1 = wide open).
-static void set_talk(float open)
-{
-  if (open < 0) open = 0;
-  if (open > 1) open = 1;
-  int h = (int)(8 + 24.0f * open);
-  lv_obj_set_size(talk, 58, h);
-  lv_obj_align(talk, LV_ALIGN_CENTER, 0, MOUTH_DY + 2);
-}
-
 void Face_SetState(WbState state)
 {
   current = state;
@@ -205,13 +224,17 @@ void Face_SetState(WbState state)
 
   show(eye_l, face);
   show(eye_r, face);
-  show(smile, face);                  // keep the happy smile in every face state
-  show(talk, speak);                  // moving mouth only while speaking
+  show(pupil_l, face);
+  show(pupil_r, face);
+  show(mouth, face);
+  show(teeth, face);
+  show(tongue, face);
   for (int i = 0; i < 3; i++) show(comets[i], glow);
   show(letter_lbl, spell);
   show(word_lbl, spell);
 
-  if (face) set_smile(listen || speak);    // big happy smile while listening AND speaking
+  // A static happy mouth per state; SPEAKING animates it in Face_Tick.
+  if (face && !speak) set_mouth(listen ? 0.95f : think ? 0.5f : 0.66f);
 
   uint32_t now = lv_tick_get();
   blink_start_ms = 0;
@@ -227,7 +250,7 @@ void Face_ShowVolume(int pct)
   if (pct > 100) pct = 100;
   lv_arc_set_value(vol_arc, pct);
   lv_obj_clear_flag(vol_arc, LV_OBJ_FLAG_HIDDEN);
-  vol_hide_ms = lv_tick_get() + 1500;   // auto-hide after 1.5s
+  vol_hide_ms = lv_tick_get() + 1500;
 }
 
 void Face_ShowSpelling(const char *word)
@@ -259,33 +282,45 @@ static float blink_factor(uint32_t now)
   return 1.0f;
 }
 
-// Smoothly wander the eyes to make the face feel alive.
 static void update_gaze(uint32_t now, bool wander)
 {
   if (wander && now >= gaze_next_ms) {
-    if (esp_random() % 3 == 0) { gaze_tx = 0; gaze_ty = 0; }      // often re-center
+    if (esp_random() % 3 == 0) { gaze_tx = 0; gaze_ty = 0; }
     else {
-      gaze_tx = ((int)(esp_random() % 29) - 14);                  // -14..14
-      gaze_ty = ((int)(esp_random() % 15) - 7);                   // -7..7
+      gaze_tx = ((int)(esp_random() % 25) - 12);
+      gaze_ty = ((int)(esp_random() % 13) - 6);
     }
     gaze_next_ms = now + 900 + (esp_random() % 1500);
   }
-  gaze_cx += (gaze_tx - gaze_cx) * 0.12f;                          // ease toward target
+  gaze_cx += (gaze_tx - gaze_cx) * 0.12f;
   gaze_cy += (gaze_ty - gaze_cy) * 0.12f;
 }
 
+// Position eyes (white) and pupils. `open` (from blink) squashes them shut.
 static void place_eyes(float open)
 {
-  int h = (int)(6 + (EYE_D - 6) * open);
-  if (h < 6) h = 6;
-  int dx = (int)gaze_cx, dy = (int)gaze_cy;
-  lv_obj_set_height(eye_l, h);
-  lv_obj_set_height(eye_r, h);
-  lv_obj_align(eye_l, LV_ALIGN_CENTER, -EYE_DX + dx, EYE_DY + dy);
-  lv_obj_align(eye_r, LV_ALIGN_CENTER, EYE_DX + dx, EYE_DY + dy);
+  int eh = (int)(EYE_D * open);
+  if (eh < 6) eh = 6;
+  lv_obj_set_size(eye_l, EYE_D, eh);
+  lv_obj_set_size(eye_r, EYE_D, eh);
+  lv_obj_align(eye_l, LV_ALIGN_CENTER, -EYE_DX, EYE_DY);
+  lv_obj_align(eye_r, LV_ALIGN_CENTER,  EYE_DX, EYE_DY);
+
+  bool pv = open > 0.4f;
+  show(pupil_l, pv);
+  show(pupil_r, pv);
+  if (pv) {
+    int px = (int)gaze_cx;
+    int py = (int)gaze_cy + 6;                 // slight downward gaze = cuter
+    int ph = (int)(PUPIL_D * open);
+    if (ph < 6) ph = 6;
+    lv_obj_set_size(pupil_l, PUPIL_D, ph);
+    lv_obj_set_size(pupil_r, PUPIL_D, ph);
+    lv_obj_align(pupil_l, LV_ALIGN_CENTER, -EYE_DX + px, EYE_DY + py);
+    lv_obj_align(pupil_r, LV_ALIGN_CENTER,  EYE_DX + px, EYE_DY + py);
+  }
 }
 
-// Rotate the three glow arcs to make a smooth flowing edge of light.
 static void spin_edge(float base_deg, lv_opa_t opa)
 {
   for (int i = 0; i < 3; i++) {
@@ -301,7 +336,6 @@ void Face_Tick(void)
   uint32_t now = lv_tick_get();
   float t = now / 1000.0f;
 
-  // Auto-hide the volume bar.
   if (vol_hide_ms != 0 && now >= vol_hide_ms) {
     lv_obj_add_flag(vol_arc, LV_OBJ_FLAG_HIDDEN);
     vol_hide_ms = 0;
@@ -316,24 +350,23 @@ void Face_Tick(void)
     case WB_LISTENING:
       update_gaze(now, true);
       place_eyes(blink_factor(now));
-      spin_edge(t * 210.0f, 220);            // bright, fast, flowing
+      spin_edge(t * 210.0f, 220);
       break;
 
     case WB_THINKING:
-      gaze_tx = 0; gaze_ty = -8;             // glance up, pondering
+      gaze_tx = 0; gaze_ty = -8;
       update_gaze(now, false);
       place_eyes(blink_factor(now));
-      spin_edge(t * 75.0f, 110);             // slow, gentle
+      spin_edge(t * 75.0f, 110);
       break;
 
     case WB_SPEAKING: {
-      // Happy talking: smile stays, mouth opens/closes, eyes wander, edge flows.
       update_gaze(now, true);
       place_eyes(blink_factor(now));
       spin_edge(t * 130.0f, 190);
-      // Two overlapping rates make the flapping feel like natural speech.
-      float m = 0.5f + 0.35f * sinf(t * 15.0f) + 0.15f * sinf(t * 6.3f);
-      set_talk(m);
+      // Natural-looking talking: two rates combined for the mouth open amount.
+      float m = 0.55f + 0.30f * sinf(t * 13.0f) + 0.15f * sinf(t * 7.0f);
+      set_mouth(m);
       break;
     }
 

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -1,22 +1,18 @@
 /*****************************************************************************
- * The WonderBox face — a cute cartoon character.
+ * The WonderBox face — a cute cartoon character on a blue background.
  *
- * Design (matches the "big-eyes + open smile" cartoon reference):
- *   - two big white eyes with bold outlines and black pupils that wander + blink
- *   - a friendly OPEN mouth: black cavity, a white row of teeth on top, and a
- *     pink tongue at the bottom. While speaking, the mouth opens and closes.
- *   - a soft, flowing "Siri-style" glow around the round edge while it is
- *     listening / thinking / speaking.
+ * Two looks, matching the reference art:
+ *   SITTING STILL (idle/listening/thinking):
+ *       two big white eyes with black pupils that wander + blink, and a small
+ *       gentle smile.
+ *   ANSWERING (speaking):
+ *       happy closed "∩ ∩" eyes and an open black mouth with a pink tongue that
+ *       opens and closes as it talks.
  *
- * Per-state looks:
- *   IDLE      calm happy face, eyes wander + blink, mouth softly open
- *   LISTENING big open smile + bright fast flowing edge
- *   THINKING  eyes glance up + slow dim edge, smaller mouth
- *   SPEAKING  mouth opens/closes like talking + medium flowing edge
- *   SPELLING  one big letter at a time
+ *   SPELLING shows one big letter at a time.
  *
- * Everything is drawn with LVGL primitives so it stays crisp. Only moving parts
- * update each frame.
+ * A soft flowing edge glow appears only while listening / thinking (feedback
+ * that it's busy); the idle and speaking faces are clean, like the reference.
  *****************************************************************************/
 #include "face.h"
 #include <Arduino.h>
@@ -25,36 +21,36 @@
 #include <ctype.h>
 
 // ---- Palette ----
-#define COL_BG      0xFFF3E0   // warm cream
-#define COL_OUTLINE 0x2B2B33   // bold cartoon outline / pupils
+#define COL_BG      0x4C90D9   // friendly blue
+#define COL_INK     0x1E1E24   // near-black: pupils, eye arcs, smile, mouth
 #define COL_EYE     0xFFFFFF   // eye white
-#define COL_MOUTH   0x2B2B33   // open mouth cavity
-#define COL_TEETH   0xFFFFFF   // top teeth
-#define COL_TONGUE  0xFF7EA6   // pink tongue
-#define COL_LETTER  0x2E7DE1
-// Cool, Siri-like flowing edge colors
-#define COL_GLOW1   0x37D6D6
-#define COL_GLOW2   0x4AA8FF
-#define COL_GLOW3   0x8E7BFF
-#define COL_VOLTRK  0xE7DECB
-#define COL_VOLFILL 0x4AA8FF
+#define COL_TONGUE  0xEE6F9E   // pink tongue
+#define COL_LETTER  0xFFFFFF
+// Cool, Siri-like flowing edge colors (listening/thinking only)
+#define COL_GLOW1   0x9BE8FF
+#define COL_GLOW2   0xBFD4FF
+#define COL_GLOW3   0xE7C7FF
+#define COL_VOLTRK  0x3C79B8
+#define COL_VOLFILL 0xFFFFFF
 
 // ---- Geometry (screen 360x360, center 180,180) ----
-static const int EYE_D    = 98;    // eye diameter
-static const int EYE_DX   = 46;    // eye horizontal offset (they nearly touch)
-static const int EYE_DY   = -36;   // eye vertical offset from center
-static const int PUPIL_D  = 44;
-static const int MOUTH_W  = 150;
-static const int MOUTH_DY = 74;    // mouth center offset from screen center
-static const int MOUTH_MIN = 46;
-static const int MOUTH_MAX = 98;
+static const int EYE_D    = 118;   // big eyes
+static const int EYE_DX   = 52;    // horizontal offset (eyes overlap a little)
+static const int EYE_DY   = -34;
+static const int PUPIL_D  = 48;
+static const int MOUTH_W  = 148;
+static const int MOUTH_DY = 82;    // mouth center offset from screen center
+static const int MOUTH_MIN = 38;
+static const int MOUTH_MAX = 108;
 static const int EDGE_D   = 352;
 
 // ---- Objects ----
-static lv_obj_t *eye_l, *eye_r;
-static lv_obj_t *pupil_l, *pupil_r;
-static lv_obj_t *mouth, *teeth, *tongue;
-static lv_obj_t *comets[3];
+static lv_obj_t *eye_l, *eye_r;        // white eyes (still)
+static lv_obj_t *pupil_l, *pupil_r;    // pupils (still)
+static lv_obj_t *eyearc_l, *eyearc_r;  // happy closed eyes (speaking)
+static lv_obj_t *smile;                // gentle smile (still)
+static lv_obj_t *mouth, *tongue;       // open talking mouth (speaking)
+static lv_obj_t *comets[3];            // edge glow (listening/thinking)
 static lv_obj_t *vol_arc;
 static lv_obj_t *letter_lbl, *word_lbl;
 
@@ -75,7 +71,7 @@ static int spell_len = 0, spell_index = 0;
 static uint32_t spell_last_ms = 0;
 static const uint32_t SPELL_STEP_MS = 800;
 
-static lv_obj_t *make_rect(lv_obj_t *parent, uint32_t fill, uint32_t outline, int border, bool circle)
+static lv_obj_t *make_rect(lv_obj_t *parent, uint32_t fill, bool circle)
 {
   lv_obj_t *o = lv_obj_create(parent);
   lv_obj_remove_style_all(o);
@@ -84,15 +80,12 @@ static lv_obj_t *make_rect(lv_obj_t *parent, uint32_t fill, uint32_t outline, in
   lv_obj_set_style_radius(o, circle ? LV_RADIUS_CIRCLE : 0, 0);
   lv_obj_set_style_bg_color(o, lv_color_hex(fill), 0);
   lv_obj_set_style_bg_opa(o, LV_OPA_COVER, 0);
-  if (border > 0) {
-    lv_obj_set_style_border_color(o, lv_color_hex(outline), 0);
-    lv_obj_set_style_border_width(o, border, 0);
-    lv_obj_set_style_border_opa(o, LV_OPA_COVER, 0);
-  }
   return o;
 }
 
-static lv_obj_t *make_arc(lv_obj_t *parent, uint32_t color, int size, int width)
+// A stroked arc segment (used for the smile and the happy closed eyes).
+static lv_obj_t *make_arc_seg(lv_obj_t *parent, uint32_t color, int size,
+                              int width, int a0, int a1, bool rounded)
 {
   lv_obj_t *a = lv_arc_create(parent);
   lv_obj_remove_style_all(a);
@@ -101,10 +94,10 @@ static lv_obj_t *make_arc(lv_obj_t *parent, uint32_t color, int size, int width)
   lv_obj_set_size(a, size, size);
   lv_obj_center(a);
   lv_arc_set_rotation(a, 0);
-  lv_arc_set_bg_angles(a, 0, 10);
+  lv_arc_set_bg_angles(a, a0, a1);
   lv_obj_set_style_arc_color(a, lv_color_hex(color), LV_PART_MAIN);
   lv_obj_set_style_arc_width(a, width, LV_PART_MAIN);
-  lv_obj_set_style_arc_rounded(a, true, LV_PART_MAIN);
+  lv_obj_set_style_arc_rounded(a, rounded, LV_PART_MAIN);
   lv_obj_set_style_arc_width(a, 0, LV_PART_INDICATOR);
   lv_obj_set_style_bg_opa(a, LV_OPA_TRANSP, LV_PART_KNOB);
   lv_obj_set_style_pad_all(a, 0, LV_PART_KNOB);
@@ -120,26 +113,25 @@ static inline void show(lv_obj_t *o, bool v)
 static void schedule_blink(uint32_t now) { blink_next_ms = now + 2400 + (esp_random() % 2600); }
 
 // Shape the open mouth by `open` (0 = nearly closed, 1 = wide open), keeping the
-// white teeth hugging the top and the pink tongue at the bottom.
+// pink tongue filling the bottom.
 static void set_mouth(float open)
 {
   if (open < 0.10f) open = 0.10f;
   if (open > 1.0f) open = 1.0f;
   int mh = MOUTH_MIN + (int)((MOUTH_MAX - MOUTH_MIN) * open);
+  int rad = mh / 2;
+  if (rad > 46) rad = 46;
 
   lv_obj_set_size(mouth, MOUTH_W, mh);
-  lv_obj_set_style_radius(mouth, mh / 2, 0);
+  lv_obj_set_style_radius(mouth, rad, 0);
   lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
 
-  int tw = MOUTH_W - 30, th = 22;
-  lv_obj_set_size(teeth, tw, th);
-  lv_obj_align(teeth, LV_ALIGN_CENTER, 0, MOUTH_DY - mh / 2 + th / 2 + 5);
-
-  int tgw = 74, tgh = (int)(mh * 0.42f);
-  if (tgh > 42) tgh = 42;
-  if (tgh < 14) tgh = 14;
+  int tgw = (int)(MOUTH_W * 0.62f);
+  int tgh = (int)(mh * 0.5f);
+  if (tgh > 46) tgh = 46;
+  if (tgh < 12) tgh = 12;
   lv_obj_set_size(tongue, tgw, tgh);
-  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + mh / 2 - tgh / 2 - 5);
+  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + mh / 2 - tgh / 2 - 3);
 }
 
 void Face_Create(void)
@@ -152,24 +144,31 @@ void Face_Create(void)
   // Edge glow (behind everything).
   const uint32_t glow_cols[3] = {COL_GLOW1, COL_GLOW2, COL_GLOW3};
   for (int i = 0; i < 3; i++) {
-    comets[i] = make_arc(scr, glow_cols[i], EDGE_D, 10);
-    lv_arc_set_bg_angles(comets[i], 0, 110);
+    comets[i] = make_arc_seg(scr, glow_cols[i], EDGE_D, 10, 0, 110, true);
   }
 
-  // Mouth group (create before eyes; eyes/pupils sit visually above).
-  mouth  = make_rect(scr, COL_MOUTH, COL_OUTLINE, 4, false);
-  teeth  = make_rect(scr, COL_TEETH, 0, 0, false);
-  lv_obj_set_style_radius(teeth, 9, 0);
-  tongue = make_rect(scr, COL_TONGUE, 0, 0, true);
-  set_mouth(0.66f);
+  // Talking mouth (speaking): black cavity + pink tongue (drawn on top).
+  mouth  = make_rect(scr, COL_INK, false);
+  tongue = make_rect(scr, COL_TONGUE, true);
+  set_mouth(0.6f);
 
-  // Big cartoon eyes: white with a bold outline, black pupils inside.
-  eye_l = make_rect(scr, COL_EYE, COL_OUTLINE, 5, true);
-  eye_r = make_rect(scr, COL_EYE, COL_OUTLINE, 5, true);
+  // Gentle smile (still): a shallow upturned arc.
+  smile = make_arc_seg(scr, COL_INK, 96, 9, 35, 145, true);
+  lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - 40);
+
+  // Happy closed eyes (speaking): two upward arcs "∩ ∩".
+  eyearc_l = make_arc_seg(scr, COL_INK, 92, 12, 210, 330, true);
+  eyearc_r = make_arc_seg(scr, COL_INK, 92, 12, 210, 330, true);
+  lv_obj_align(eyearc_l, LV_ALIGN_CENTER, -EYE_DX, EYE_DY + 18);
+  lv_obj_align(eyearc_r, LV_ALIGN_CENTER,  EYE_DX, EYE_DY + 18);
+
+  // Big white eyes with pupils (still).
+  eye_l = make_rect(scr, COL_EYE, true);
+  eye_r = make_rect(scr, COL_EYE, true);
   lv_obj_set_size(eye_l, EYE_D, EYE_D);
   lv_obj_set_size(eye_r, EYE_D, EYE_D);
-  pupil_l = make_rect(scr, COL_OUTLINE, 0, 0, true);
-  pupil_r = make_rect(scr, COL_OUTLINE, 0, 0, true);
+  pupil_l = make_rect(scr, COL_INK, true);
+  pupil_r = make_rect(scr, COL_INK, true);
   lv_obj_set_size(pupil_l, PUPIL_D, PUPIL_D);
   lv_obj_set_size(pupil_r, PUPIL_D, PUPIL_D);
 
@@ -180,7 +179,7 @@ void Face_Create(void)
   lv_obj_align(letter_lbl, LV_ALIGN_CENTER, 0, -18);
 
   word_lbl = lv_label_create(scr);
-  lv_obj_set_style_text_color(word_lbl, lv_color_hex(COL_OUTLINE), 0);
+  lv_obj_set_style_text_color(word_lbl, lv_color_hex(COL_LETTER), 0);
   lv_obj_set_style_text_font(word_lbl, &lv_font_montserrat_28, 0);
   lv_label_set_text(word_lbl, "");
   lv_obj_align(word_lbl, LV_ALIGN_CENTER, 0, 70);
@@ -215,26 +214,30 @@ void Face_SetState(WbState state)
   current = state;
   Serial.printf("[face] state -> %s\n", wb_state_name(state));
 
-  const bool face   = (state != WB_SPELLING);
   const bool listen = (state == WB_LISTENING);
   const bool think  = (state == WB_THINKING);
   const bool speak  = (state == WB_SPEAKING);
   const bool spell  = (state == WB_SPELLING);
-  const bool glow   = (listen || think || speak);
+  const bool rest   = (state == WB_IDLE || listen || think);  // "sitting still" look
+  const bool glow   = (listen || think);
 
-  show(eye_l, face);
-  show(eye_r, face);
-  show(pupil_l, face);
-  show(pupil_r, face);
-  show(mouth, face);
-  show(teeth, face);
-  show(tongue, face);
+  // Still look: white eyes + pupils + smile.
+  show(eye_l, rest);
+  show(eye_r, rest);
+  show(pupil_l, rest);
+  show(pupil_r, rest);
+  show(smile, rest);
+  // Answering look: happy closed eyes + open mouth + tongue.
+  show(eyearc_l, speak);
+  show(eyearc_r, speak);
+  show(mouth, speak);
+  show(tongue, speak);
+
   for (int i = 0; i < 3; i++) show(comets[i], glow);
   show(letter_lbl, spell);
   show(word_lbl, spell);
 
-  // A static happy mouth per state; SPEAKING animates it in Face_Tick.
-  if (face && !speak) set_mouth(listen ? 0.95f : think ? 0.5f : 0.66f);
+  if (speak) set_mouth(0.5f);
 
   uint32_t now = lv_tick_get();
   blink_start_ms = 0;
@@ -296,7 +299,6 @@ static void update_gaze(uint32_t now, bool wander)
   gaze_cy += (gaze_ty - gaze_cy) * 0.12f;
 }
 
-// Position eyes (white) and pupils. `open` (from blink) squashes them shut.
 static void place_eyes(float open)
 {
   int eh = (int)(EYE_D * open);
@@ -311,7 +313,7 @@ static void place_eyes(float open)
   show(pupil_r, pv);
   if (pv) {
     int px = (int)gaze_cx;
-    int py = (int)gaze_cy + 6;                 // slight downward gaze = cuter
+    int py = (int)gaze_cy + 6;
     int ph = (int)(PUPIL_D * open);
     if (ph < 6) ph = 6;
     lv_obj_set_size(pupil_l, PUPIL_D, ph);
@@ -361,10 +363,7 @@ void Face_Tick(void)
       break;
 
     case WB_SPEAKING: {
-      update_gaze(now, true);
-      place_eyes(blink_factor(now));
-      spin_edge(t * 130.0f, 190);
-      // Natural-looking talking: two rates combined for the mouth open amount.
+      // Happy closed eyes stay put; the mouth opens/closes like talking.
       float m = 0.55f + 0.30f * sinf(t * 13.0f) + 0.15f * sinf(t * 7.0f);
       set_mouth(m);
       break;

--- a/questionbox/server/__tests__/pipeline.test.ts
+++ b/questionbox/server/__tests__/pipeline.test.ts
@@ -51,7 +51,9 @@ describe("pipeline — Gate 1 (LLM classifier) can still defer", () => {
       generate,
     });
     expect(res.mode).toBe("deferred");
-    expect(generate).not.toHaveBeenCalled();
+    // The answer model may run speculatively (in parallel) for latency, but its
+    // output is discarded — a deferred question must never leak a substantive answer.
+    expect(res.text).not.toContain("substantive");
   });
 
   it("defers when the classifier throws (fail closed)", async () => {

--- a/questionbox/server/app/api/ask/route.ts
+++ b/questionbox/server/app/api/ask/route.ts
@@ -50,11 +50,16 @@ export async function POST(request: Request): Promise<Response> {
 
   const startedAt = Date.now();
 
+  // Load editable rules NOW, concurrently with transcription — they don't depend
+  // on the question, so the Supabase fetch overlaps STT instead of adding latency.
+  const rulesPromise = getRules();
+
   // 1) Speech-to-text (audio discarded right after).
   let question = "";
   try {
     question = await transcribe(audio);
   } catch (e) {
+    rulesPromise.catch(() => {}); // don't leak the pending rules fetch
     const msg = String((e as Error)?.message ?? e);
     console.error("[ask] STT failed:", msg);
     const text = troubleMessage();
@@ -65,11 +70,22 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // 2) Safety pipeline (2 gates + deterministic checks) -> answer text.
-  const rules = await getRules(); // editable rules from Supabase (or defaults)
+  const rules = await rulesPromise; // editable rules from Supabase (or defaults)
   const result = await answerQuestion(question, makeRealDeps(rules), rules);
+  console.log(`[ask] q="${question}" -> mode=${result.mode} cat=${result.category ?? "-"}`);
 
-  // 3) Text-only logging to Supabase (audio is NEVER logged). Best-effort.
-  await logInteraction({
+  // 3) & 4) Text-to-speech and text-only logging run CONCURRENTLY: logging no
+  // longer sits on the critical path in front of the audio (audio is never logged).
+  const ttsPromise = (async (): Promise<{ wav: Buffer; debug: string }> => {
+    try {
+      return { wav: await synthesize(result.text), debug: "" };
+    } catch (e) {
+      const debug = "tts:" + String((e as Error)?.message ?? e);
+      console.error("[ask] TTS failed:", debug);
+      return { wav: generateChimeWav(), debug };
+    }
+  })();
+  const logPromise = logInteraction({
     question,
     answer: result.text,
     mode: result.mode,
@@ -79,18 +95,8 @@ export async function POST(request: Request): Promise<Response> {
     spellWord: result.spellWord,
     latencyMs: Date.now() - startedAt,
   });
-  console.log(`[ask] q="${question}" -> mode=${result.mode} cat=${result.category ?? "-"}`);
 
-  // 4) Text-to-speech.
-  let ttsDebug = "";
-  let wav: Buffer;
-  try {
-    wav = await synthesize(result.text);
-  } catch (e) {
-    ttsDebug = "tts:" + String((e as Error)?.message ?? e);
-    console.error("[ask] TTS failed:", ttsDebug);
-    wav = generateChimeWav();
-  }
+  const [{ wav, debug: ttsDebug }] = await Promise.all([ttsPromise, logPromise]);
 
   const answer: WonderAnswer = {
     text: result.text,

--- a/questionbox/server/lib/ai/tts.ts
+++ b/questionbox/server/lib/ai/tts.ts
@@ -15,18 +15,25 @@ export async function synthesize(text: string): Promise<Buffer> {
 
 async function synthesizeOpenAI(text: string): Promise<Buffer> {
   const openai = getOpenAI();
-  const model = process.env.TTS_MODEL || "gpt-4o-mini-tts";
+  // Default to tts-1: it has much lower latency than gpt-4o-mini-tts, which makes
+  // the box feel noticeably snappier. "nova" is warm on its own. Set TTS_MODEL to
+  // "gpt-4o-mini-tts" if you want the steerable (but slower) voice.
+  const model = process.env.TTS_MODEL || "tts-1";
   const voice = process.env.TTS_VOICE || "nova";
 
-  const res = await openai.audio.speech.create({
+  const params: Parameters<typeof openai.audio.speech.create>[0] = {
     model,
     voice,
     input: text,
     response_format: "pcm", // raw 24kHz mono 16-bit LE
-    instructions:
-      "Speak in a warm, gentle, friendly female voice, slowly and clearly, as if reading to a young child.",
-  });
+  };
+  // Only the steerable gpt-4o TTS models accept `instructions`; tts-1 rejects it.
+  if (model.includes("gpt-4o")) {
+    params.instructions =
+      "Speak in a warm, gentle, friendly female voice, slowly and clearly, as if reading to a young child.";
+  }
 
+  const res = await openai.audio.speech.create(params);
   const pcm = Buffer.from(await res.arrayBuffer());
   return encodeWav(pcm, { sampleRate: 24000, numChannels: 1 });
 }

--- a/questionbox/server/lib/pipeline.ts
+++ b/questionbox/server/lib/pipeline.ts
@@ -83,20 +83,34 @@ export async function answerQuestion(
     };
   }
 
-  // --- Gate 1: LLM classifier (default to defer on anything but "answer") ---
+  // --- Gates 1 & 2 run CONCURRENTLY (to cut latency) ---
+  // Both safety gates are still fully enforced: the generated answer is only USED
+  // if the classifier returns "answer" AND every post-check below passes. Kicking
+  // off both LLM calls together just removes one round-trip from the common
+  // (answerable) path; the speculative answer is discarded when we defer/refuse.
+  const clsPromise = deps.classify(q);
+  const genPromise = deps.generate(q);
+
   let cls: { decision: "answer" | "defer" | "refuse"; category?: string; reason?: string };
   try {
-    cls = await deps.classify(q);
+    cls = await clsPromise;
   } catch {
+    genPromise.catch(() => {}); // discard the speculative answer's result/rejection
     return defer(q, "classify_error");
   }
-  if (cls.decision === "refuse") return refuse(cls.reason ?? "llm_refuse", cls.category);
-  if (cls.decision !== "answer") return defer(q, cls.reason ?? "llm_defer", cls.category);
+  if (cls.decision === "refuse") {
+    genPromise.catch(() => {});
+    return refuse(cls.reason ?? "llm_refuse", cls.category);
+  }
+  if (cls.decision !== "answer") {
+    genPromise.catch(() => {});
+    return defer(q, cls.reason ?? "llm_defer", cls.category);
+  }
 
   // --- Gate 2: answer model under the strict system prompt ---
   let raw: string;
   try {
-    raw = await deps.generate(q);
+    raw = await genPromise;
   } catch {
     return defer(q, "generate_error", cls.category);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Brings the **proven V2 audio** into the main WonderBox firmware and iterates on face, playback smoothness, and end-to-end latency. Mic + speaker confirmed working on hardware.

### V2 audio (device works)
- **ES7210 mic** (16 kHz) + **ES8311 speaker** (24 kHz) + **amp on GPIO15**, all over I2C (`Wire`).
- **One shared full-duplex I2S** on V2 pins (`MCLK 2, BCK 48, WS 38, DOUT 47, DIN 39`), legacy driver (PSRAM-safe). Record 16 kHz / playback 24 kHz via `i2s_set_clk`.

### Smooth + fast playback (device)
- **Two tasks pinned to core 0** — a *producer* that downloads the answer into PSRAM at full link speed and a *consumer* that feeds I2S — both separate from the UI (core 1). Neither the network nor LVGL can starve the audio, which eliminates the choppiness.
- Small **~16 KB pre-buffer** so playback starts quickly.

### Faster round-trip (server) — the "delay before the answer" fix
- **Classifier + answer LLM run in parallel** instead of sequentially. Both safety gates are still fully enforced (the classifier still decides whether the answer is used; the speculative answer is discarded on defer/refuse) — this just removes one LLM round-trip from the common answerable path.
- **Rules fetch overlaps STT** (rules don't depend on the question).
- **Logging overlaps TTS** (logging no longer sits in front of the audio on the critical path).
- **TTS defaults to the low-latency `tts-1`** model (still `nova`, still swappable via `TTS_MODEL`).

### Face — matches the reference art
Blue background, two clear looks:
- **Sitting still** (idle/listening/thinking): big **white eyes with black pupils** that wander + blink, and a small **gentle smile**.
- **Answering** (speaking): **happy closed "∩ ∩" eyes** and an **open black mouth with a pink tongue** that grows in both width and height as it talks (small round "o" → big open mouth), matching the 5-frame reference.
- Spelling shows one big letter at a time; a faint edge glow appears only while listening/thinking.

## Build & tests
- Firmware: compiles clean with PSRAM on (RAM 43.9%, Flash 21.6%).
- Server: all 90 tests pass (safety gates verified: blocked/deferred never get a substantive answer, even with a permissive LLM).

## Testing note
Face positions (eye/mouth offsets) are single-number tweaks if anything sits slightly high/low on the round display.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

