### PR TITLE
WonderBox: wider talking mouth, closer resting face, and 16 kHz audio (smoother + faster)

### DIFF
--- a/questionbox/firmware/src/audio/audio_codecs.cpp
+++ b/questionbox/firmware/src/audio/audio_codecs.cpp
@@ -26,7 +26,7 @@
 
 #define PA_ENABLE_PIN 15
 #define MIC_RATE      16000
-#define SPK_RATE      24000
+#define SPK_RATE      16000   // match the mic rate: one clock, less audio data
 #define MCLK_MULTIPLE 256
 
 static es7210_dev_handle_t s_es7210 = NULL;
@@ -68,7 +68,7 @@ static bool init_spk_codec(void)
   clk.mclk_inverted     = false;
   clk.sclk_inverted     = false;
   clk.mclk_from_mclk_pin = true;
-  clk.mclk_frequency    = SPK_RATE * MCLK_MULTIPLE;   // 6.144 MHz
+  clk.mclk_frequency    = SPK_RATE * MCLK_MULTIPLE;   // 4.096 MHz @16kHz
   clk.sample_frequency  = SPK_RATE;
   if (es8311_init(s_es8311, &clk, ES8311_RESOLUTION_16, ES8311_RESOLUTION_16) != ESP_OK) {
     Serial.println("[codec] ES8311 init FAILED");
@@ -76,7 +76,7 @@ static bool init_spk_codec(void)
   }
   es8311_voice_volume_set(s_es8311, 60, NULL);  // codec base level; app gain rides on top
   es8311_microphone_config(s_es8311, false);   // don't use ES8311's own mic
-  Serial.println("[codec] ES8311 speaker configured @24kHz");
+  Serial.println("[codec] ES8311 speaker configured @16kHz");
   return true;
 }
 

--- a/questionbox/firmware/src/audio/speaker.cpp
+++ b/questionbox/firmware/src/audio/speaker.cpp
@@ -65,8 +65,8 @@ static int read_exact(Stream &s, uint8_t *buf, int want, void (*pump)())
 
 void Speaker_TestBeep()
 {
-  const int rate = 24000;
-  AudioBus_SetSampleRate(rate);      // clock the speaker codec for playback
+  const int rate = 16000;            // whole audio path runs at 16 kHz now
+  AudioBus_SetSampleRate(rate);
   const int total = rate / 2;        // 0.5 seconds
   int16_t buf[256 * 2];
   int done = 0;
@@ -101,7 +101,6 @@ static volatile int  s_filled   = 0;      // bytes downloaded so far
 static uint8_t      *s_buf      = nullptr;
 static int           s_total    = 0;      // total content length (WAV header + PCM)
 static Stream       *s_stream   = nullptr;
-static uint32_t      s_rate     = 24000;
 static void        (*s_onStart)() = nullptr;
 static int16_t s_stereo[512 * 2];         // static so the task stacks stay small
 
@@ -116,6 +115,11 @@ static void producer_task(void *)
   while (got < s_total) {
     int want = s_total - got;
     if (want > 4096) want = 4096;
+    // Read only what's already arrived so we never block waiting for a full
+    // chunk (that would let the consumer catch up and stutter).
+    int av = s_stream->available();
+    if (av <= 0) { vTaskDelay(1); if (millis() > stall) break; continue; }
+    if (want > av) want = av;
     int n = s_stream->readBytes((char *)(s_buf + got), want);
     if (n > 0) { got += n; s_filled = got; stall = millis() + 6000; }
     else { vTaskDelay(1); if (millis() > stall) break; }
@@ -126,18 +130,13 @@ static void producer_task(void *)
 
 static void consumer_task(void *)
 {
-  // Wait for the 44-byte WAV header, then match the bus clock to its sample rate.
-  while (s_filled < 44 && !s_dlDone) vTaskDelay(1);
-  if (s_filled >= 44) {
-    uint32_t r = *(uint32_t *)(s_buf + 24);
-    if (r >= 8000 && r <= 48000) s_rate = r;
-  }
+  // The whole audio path is fixed at 16 kHz now, so we don't retune the bus off
+  // the WAV header — we just skip the 44-byte header and play the PCM.
   // Small pre-buffer so a first-packet hiccup can't clip the opening word.
   int prebuf = 44 + PREBUF_BYTES;
   if (prebuf > s_total) prebuf = s_total;
   while (s_filled < prebuf && !s_dlDone) vTaskDelay(1);
 
-  AudioBus_SetSampleRate(s_rate);
   if (s_onStart) s_onStart();              // start the mouth as sound starts
 
   int pos = 44;                            // skip the WAV header
@@ -163,7 +162,6 @@ static void consumer_task(void *)
     pos += nbytes;
   }
   delay(120);                              // let the DMA tail drain
-  AudioBus_SetSampleRate(16000);           // hand the bus back to the mic
   s_playDone = true;
   vTaskDelete(nullptr);
 }
@@ -206,7 +204,6 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onA
       s_filled = 0;
       s_dlDone = false;
       s_playDone = false;
-      s_rate = 24000;
       s_onStart = onAudioStart;
       // Consumer runs at a slightly higher priority so feeding I2S always wins.
       xTaskCreatePinnedToCore(producer_task, "spkdl",  4096, nullptr, 5, nullptr, 0);
@@ -230,11 +227,8 @@ void Speaker_PlayWavStream(Stream &s, int contentLen, void (*pump)(), void (*onA
     Serial.println("[spk] not a WAV stream");
     return;
   }
-  uint32_t wavRate = *(uint32_t *)(header + 24);
   int dataLen = (contentLen > 44) ? (contentLen - 44) : -1;
-  if (wavRate >= 8000 && wavRate <= 48000) AudioBus_SetSampleRate(wavRate);
   if (onAudioStart) onAudioStart();
   play_stream(s, (dataLen > 0) ? dataLen : INT32_MAX, pump);
-  AudioBus_SetSampleRate(16000);
   Serial.println("[spk] playback done (streamed)");
 }

--- a/questionbox/firmware/src/main.cpp
+++ b/questionbox/firmware/src/main.cpp
@@ -53,10 +53,18 @@ static bool     g_btn_down = false;
 static uint32_t g_btn_down_ms = 0;
 static bool     g_btn_long_fired = false;
 
+// Set by the audio (consumer) task to ask the main loop to switch the face to
+// SPEAKING. LVGL is single-threaded, so the audio task must NEVER call Face_*
+// itself — it only raises this flag, and pump_ui() (main loop) acts on it.
+static volatile bool g_want_speaking = false;
+
 static void note_activity() { g_last_activity = millis(); }
+
+static void request_speaking() { g_want_speaking = true; }
 
 static void pump_ui()
 {
+  if (g_want_speaking) { g_want_speaking = false; Face_SetState(WB_SPEAKING); }
   Lvgl_Loop();
   Face_Tick();
 }
@@ -105,19 +113,19 @@ static void stop_and_send()
   xTaskCreatePinnedToCore(ask_task, "ask", 16384, nullptr, 4, nullptr, 0);
 }
 
-static void set_speaking_cb() { Face_SetState(WB_SPEAKING); }
-
 static void play_answer()
 {
   Stream *body = WonderClient_GetStream();
   int len = WonderClient_GetLength();
+  g_want_speaking = false;
   if (g_ans.isSpelling && g_ans.spellWord.length() > 0) {
     Face_ShowSpelling(g_ans.spellWord.c_str());        // letters stay up during audio
     if (body) Speaker_PlayWavStream(*body, len, pump_ui, nullptr);
   } else {
     // Stay THINKING while the answer downloads; the mouth starts talking the
-    // instant audible playback begins (set_speaking_cb).
-    if (body) Speaker_PlayWavStream(*body, len, pump_ui, set_speaking_cb);
+    // instant audible playback begins (request_speaking flips a flag the main
+    // loop reads, so LVGL is only ever touched from the main thread).
+    if (body) Speaker_PlayWavStream(*body, len, pump_ui, request_speaking);
     else Face_SetState(WB_SPEAKING);
   }
   WonderClient_End();

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -244,6 +244,10 @@ void Face_SetState(WbState state)
 
   if (speak) set_mouth(0.5f);
 
+  // Force a clean full redraw so nothing from the previous state can linger
+  // (e.g. the edge glow after answering, or two mouths overlapping mid-switch).
+  lv_obj_invalidate(lv_scr_act());
+
   uint32_t now = lv_tick_get();
   blink_start_ms = 0;
   schedule_blink(now);

--- a/questionbox/firmware/src/ui/face.cpp
+++ b/questionbox/firmware/src/ui/face.cpp
@@ -36,15 +36,16 @@
 // ---- Geometry (screen 360x360, center 180,180) ----
 static const int EYE_D    = 118;   // big eyes
 static const int EYE_DX   = 52;    // horizontal offset (eyes overlap a little)
-static const int EYE_DY   = -34;
+static const int EYE_DY   = -30;   // (resting eyes sit a touch lower, nearer the mouth)
 static const int PUPIL_D  = 48;
-static const int MOUTH_DY = 70;    // mouth center offset from screen center
-// The talking mouth grows in BOTH width and height (a small round "o" that
-// opens into a big rounded shape), matching the reference art.
-static const int MOUTH_W_MIN = 66;
-static const int MOUTH_W_MAX = 152;
-static const int MOUTH_H_MIN = 30;
-static const int MOUTH_H_MAX = 104;
+static const int SMILE_DY = 20;    // resting smile offset (kept close under the eyes)
+static const int MOUTH_DY = 66;    // talking-mouth center offset from screen center
+// The talking mouth is WIDE and fairly flat, opening mostly in height, with a
+// big pink tongue filling the bottom half (matches the reference art).
+static const int MOUTH_W_MIN = 96;
+static const int MOUTH_W_MAX = 176;
+static const int MOUTH_H_MIN = 28;
+static const int MOUTH_H_MAX = 92;
 static const int EDGE_D   = 352;
 
 // ---- Objects ----
@@ -115,26 +116,27 @@ static inline void show(lv_obj_t *o, bool v)
 
 static void schedule_blink(uint32_t now) { blink_next_ms = now + 2400 + (esp_random() % 2600); }
 
-// Shape the open mouth by `open` (0 = small round mouth, 1 = wide open), keeping
-// the pink tongue nestled in the bottom.
+// Shape the open mouth by `open` (0 = small wide mouth, 1 = wide open), with a
+// big pink tongue filling the bottom half — a wide, flat, rounded cartoon mouth.
 static void set_mouth(float open)
 {
   if (open < 0.08f) open = 0.08f;
   if (open > 1.0f) open = 1.0f;
   int w = MOUTH_W_MIN + (int)((MOUTH_W_MAX - MOUTH_W_MIN) * open);
   int h = MOUTH_H_MIN + (int)((MOUTH_H_MAX - MOUTH_H_MIN) * open);
-  int rad = (w < h ? w : h) / 2;         // as round as possible = oval/pill
 
   lv_obj_set_size(mouth, w, h);
-  lv_obj_set_style_radius(mouth, rad, 0);
+  lv_obj_set_style_radius(mouth, h / 2, 0);   // rounded ends, wide flat shape
   lv_obj_align(mouth, LV_ALIGN_CENTER, 0, MOUTH_DY);
 
-  int tgw = (int)(w * 0.72f);
-  int tgh = (int)(h * 0.55f);
-  if (tgh > 46) tgh = 46;
+  // Big tongue: ~80% of the width, filling roughly the bottom 60% of the mouth,
+  // leaving a thin black rim at the very bottom and sides.
+  int tgw = (int)(w * 0.80f);
+  int tgh = (int)(h * 0.62f);
   if (tgh < 10) tgh = 10;
   lv_obj_set_size(tongue, tgw, tgh);
-  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + h / 2 - tgh / 2 - 4);
+  lv_obj_set_style_radius(tongue, tgh / 2, 0);
+  lv_obj_align(tongue, LV_ALIGN_CENTER, 0, MOUTH_DY + h / 2 - tgh / 2 - 5);
 }
 
 void Face_Create(void)
@@ -155,9 +157,9 @@ void Face_Create(void)
   tongue = make_rect(scr, COL_TONGUE, true);
   set_mouth(0.6f);
 
-  // Gentle smile (still): a small shallow upturned arc.
+  // Gentle smile (still): a small shallow upturned arc, kept close under the eyes.
   smile = make_arc_seg(scr, COL_INK, 74, 8, 40, 140, true);
-  lv_obj_align(smile, LV_ALIGN_CENTER, 0, MOUTH_DY - 18);
+  lv_obj_align(smile, LV_ALIGN_CENTER, 0, SMILE_DY);
 
   // Happy closed eyes (speaking): two rounded upward humps "∩ ∩".
   eyearc_l = make_arc_seg(scr, COL_INK, 96, 13, 200, 340, true);

--- a/questionbox/server/lib/ai/tts.ts
+++ b/questionbox/server/lib/ai/tts.ts
@@ -1,8 +1,35 @@
 import { getOpenAI } from "./openai";
 import { encodeWav } from "../wav";
 
+// The device plays audio at 16 kHz. Sending 16 kHz (instead of 24 kHz) is ~33%
+// less data over Wi-Fi, so playback downloads faster and streams without gaps.
+const OUTPUT_RATE = 16000;
+
 /**
- * Text-to-speech. Returns a 24 kHz mono 16-bit WAV (what the device expects).
+ * Downsample 24 kHz mono 16-bit PCM to 16 kHz using linear interpolation. Speech
+ * quality at 16 kHz is plenty for the box, and the smaller payload is what keeps
+ * playback smooth on marginal Wi-Fi.
+ */
+function downsample24to16(pcm24: Buffer): Buffer {
+  const inSamples = pcm24.length >> 1;
+  const outSamples = Math.floor((inSamples * OUTPUT_RATE) / 24000);
+  const out = Buffer.alloc(outSamples * 2);
+  for (let i = 0; i < outSamples; i++) {
+    const srcPos = (i * 24000) / OUTPUT_RATE; // = i * 1.5
+    const i0 = Math.floor(srcPos);
+    const frac = srcPos - i0;
+    const s0 = pcm24.readInt16LE(i0 * 2);
+    const s1 = i0 + 1 < inSamples ? pcm24.readInt16LE((i0 + 1) * 2) : s0;
+    let v = Math.round(s0 + (s1 - s0) * frac);
+    if (v > 32767) v = 32767;
+    else if (v < -32768) v = -32768;
+    out.writeInt16LE(v, i * 2);
+  }
+  return out;
+}
+
+/**
+ * Text-to-speech. Returns a 16 kHz mono 16-bit WAV (what the device expects).
  *
  * Provider is swappable via TTS_PROVIDER ("openai" | "elevenlabs") — a one-line
  * env change. Voice defaults to OpenAI's warm "nova".
@@ -34,8 +61,9 @@ async function synthesizeOpenAI(text: string): Promise<Buffer> {
   }
 
   const res = await openai.audio.speech.create(params);
-  const pcm = Buffer.from(await res.arrayBuffer());
-  return encodeWav(pcm, { sampleRate: 24000, numChannels: 1 });
+  const pcm24 = Buffer.from(await res.arrayBuffer()); // OpenAI pcm is 24 kHz
+  const pcm16 = downsample24to16(pcm24);
+  return encodeWav(pcm16, { sampleRate: OUTPUT_RATE, numChannels: 1 });
 }
 
 async function synthesizeElevenLabs(text: string): Promise<Buffer> {
@@ -45,7 +73,7 @@ async function synthesizeElevenLabs(text: string): Promise<Buffer> {
   const modelId = process.env.ELEVENLABS_MODEL_ID || "eleven_flash_v2_5";
 
   const res = await fetch(
-    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}?output_format=pcm_24000`,
+    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}?output_format=pcm_16000`,
     {
       method: "POST",
       headers: { "xi-api-key": key, "content-type": "application/json" },
@@ -54,6 +82,6 @@ async function synthesizeElevenLabs(text: string): Promise<Buffer> {
   );
   if (!res.ok) throw new Error(`ElevenLabs TTS failed: ${res.status}`);
 
-  const pcm = Buffer.from(await res.arrayBuffer());
-  return encodeWav(pcm, { sampleRate: 24000, numChannels: 1 });
+  const pcm = Buffer.from(await res.arrayBuffer()); // requested at 16 kHz
+  return encodeWav(pcm, { sampleRate: OUTPUT_RATE, numChannels: 1 });
 }

--- a/questionbox/server/lib/wav.ts
+++ b/questionbox/server/lib/wav.ts
@@ -40,7 +40,7 @@ export function encodeWav(pcm: Buffer, { sampleRate, numChannels }: WavParams): 
  * placeholder answer audio, purely to prove the speaker path end-to-end.
  * Replaced by real text-to-speech in Stage 4.
  */
-export function generateChimeWav(sampleRate = 24000): Buffer {
+export function generateChimeWav(sampleRate = 16000): Buffer {
   const notes = [523.25, 659.25, 783.99, 1046.5]; // C5 E5 G5 C6
   const noteDur = 0.16; // seconds per note
   const total = notes.length * noteDur;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up polish on top of the merged V2 audio work (#26).

## Face fixes
- **Talking mouth** reshaped to match the reference: **wide and flat**, opening mostly in height, with a **big pink tongue filling the bottom ~60%** (thin black rim). The previous shape was too tall/pill-like.
- **Resting face**: eyes lowered slightly and smile raised so **eyes and mouth sit closer together**.
- **Leftover edge-glow lines after answering + overlapping expressions — fixed.** Root cause: the "start speaking" face switch was being called from the **audio task (core 0)**, but LVGL is single-threaded (main loop, core 1). That race left objects half-hidden (glow lingering, two mouths at once). Now the audio task only raises a flag and the **main loop performs the state change**, and every state change forces a **clean full redraw** so nothing from the previous state can linger.

## Audio — smoother AND faster
The whole audio path now runs at **16 kHz** instead of 24 kHz:
- **~33% less data** over Wi-Fi → downloads faster (less delay) and streams without starving (kills the remaining choppiness on marginal links).
- Server **downsamples TTS to 16 kHz**; chime is 16 kHz; device **ES8311 fixed at 16 kHz** (same as the mic — one clock, no runtime rate switching).
- Download **producer** reads only bytes already available, so it never blocks and can't stall the playback **consumer**.

Combined with the merged server latency work (parallel classifier+answer, rules//STT, logging//TTS, `tts-1`), the round-trip should be noticeably quicker.

## Build & tests
- Firmware compiles clean with PSRAM on (RAM 43.9%, Flash 21.6%).
- Server: all 90 tests pass.

## Deploy note
Firmware changes apply on flash; the 16 kHz **server** change requires this PR merged to `main` (Vercel production). If it still feels slow after deploy, confirm `TTS_MODEL` isn't pinned to `gpt-4o-mini-tts` in the Vercel env (default is now the low-latency `tts-1`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464eb94e-141a-42bd-a469-9fcb8bd684a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

